### PR TITLE
Feat: Setup Data Types for Space page

### DIFF
--- a/.kiro/specs/spaces-page-enhancement/tasks.md
+++ b/.kiro/specs/spaces-page-enhancement/tasks.md
@@ -19,12 +19,28 @@
 
 -----
 
-- [ ] 2. Implement enhanced type definitions and data models
+- [x] 2. Implement enhanced type definitions and data models
   - Create enhanced Space interface with new fields for canvas data and collaboration settings
   - Implement ContentSource interface for document management
   - Add UploadSession and UploadFile interfaces for upload management
   - Create error handling types and interfaces
   - _Requirements: 2.2, 3.3, 6.1, 6.3_
+
+- Implementation Summary:
+  - **Knowledge Microservice Types** (owns spaces + content_sources DBs):
+    - `spaces.ts`: Enhanced Space interface with collaboration settings and processing stats
+    - `content.ts`: ContentSource interface, upload management, file processing types
+  - **Canvas Microservice Types** (separate service):
+    - `canvas.ts`: Minimal necessary Canvas types for future implementation (CanvasData, CanvasNode, etc.)
+  - **Comprehensive Type Coverage**:
+    - Upload management types (UploadSession, UploadFile, progress tracking)
+    - Error handling types for uploads, validation, and API responses  
+    - UI state types for modals, uploads, and grid/filter options
+    - Google Drive integration and file validation constants
+  - **Proper Microservice Separation**:
+    - Knowledge microservice: spaces.ts + content.ts
+    - Canvas microservice: canvas.ts (future implementation ready)
+    - Clean imports via index.ts
 
 - [ ] 3. Create space detail page infrastructure
   - Implement spaces/[spaceId]/page.tsx with three-column responsive layout

--- a/frontend/src/api/actions/spaceActions.ts
+++ b/frontend/src/api/actions/spaceActions.ts
@@ -16,8 +16,9 @@ import {
   ActionResult,
   CreateUploadURLRequest,
   CreateUploadURLResponse,
-  ContentSource
 } from '@/app/spaces/types/spaces';
+import { ContentSource } from '@/app/spaces/types/content';
+
 
 // Create gRPC metadata with Clerk JWT
 async function createMetadataWithAuth(): Promise<grpc.Metadata> {

--- a/frontend/src/api/actions/spaceActions.ts
+++ b/frontend/src/api/actions/spaceActions.ts
@@ -17,7 +17,7 @@ import {
   CreateUploadURLRequest,
   CreateUploadURLResponse,
 } from '@/app/spaces/types/spaces';
-import { ContentSource } from '@/app/spaces/types/content';
+import { ContentSource, ContentSourceType, ContentSourceStatus } from '@/app/spaces/types/content';
 
 
 // Create gRPC metadata with Clerk JWT
@@ -64,6 +64,7 @@ function protoSpaceToSpace(protoSpace: any): Space {
     keywords: [],
     accessLevel: 'private' as Space['accessLevel'],
     createdAt: createdAtIso,
+    updatedAt: updatedAtIso,
     lastUpdatedAt: updatedAtIso,
     documentCount: typeof contentCount === 'number' ? contentCount : 0,
     totalSizeBytes: 0,
@@ -74,15 +75,15 @@ function protoSpaceToSpace(protoSpace: any): Space {
 
 // Helper function to convert proto ContentSource to our TypeScript ContentSource type
 function protoContentSourceToContentSource(protoSource: any): ContentSource {
-  const statusMap: Record<number, ContentSource['processingStatus']> = {
-    0: 'pending',
-    1: 'processing', 
-    2: 'completed',
-    3: 'failed'
+  const statusMap: Record<number, ContentSourceStatus> = {
+    0: ContentSourceStatus.PENDING,
+    1: ContentSourceStatus.PROCESSING, 
+    2: ContentSourceStatus.COMPLETED,
+    3: ContentSourceStatus.FAILED
   };
   
   const status = protoSource.getStatus();
-  const processingStatus = statusMap[status] || 'pending';
+  const processingStatus = statusMap[status] || ContentSourceStatus.PENDING;
   
   return {
     id: protoSource.getId(),
@@ -91,7 +92,7 @@ function protoContentSourceToContentSource(protoSource: any): ContentSource {
     mimeType: protoSource.getMimeType() || '',
     sizeBytes: protoSource.getSizeBytes() || 0,
     processingStatus,
-    sourceType: 'file',
+    sourceType: ContentSourceType.FILE,
     createdAt: timestampToISOString(protoSource.getCreatedAt?.()),
     updatedAt: timestampToISOString(protoSource.getUpdatedAt?.()),
     contentSummary: protoSource.getContentSummary() || undefined,

--- a/frontend/src/api/actions/spaceActions.ts
+++ b/frontend/src/api/actions/spaceActions.ts
@@ -54,40 +54,47 @@ function protoSpaceToSpace(protoSpace: any): Space {
 
   const stats = protoSpace.getStats?.();
   const contentCount = stats?.getContentCount?.() || 0;
+  const linkCount = stats?.getLinkCount?.() || 0;
 
   return {
     id: protoSpace.getId(),
-    userId: protoSpace.getOwnerId?.() || protoSpace.getUserId?.() || '',
+    userId: protoSpace.getOwnerId() || '',
     title: protoSpace.getTitle(),
     description: protoSpace.getDescription(),
-    icon: protoSpace.getIcon?.() || undefined,
-    keywords: protoSpace.getKeywordsList?.() || [],
-    // Snake_case fields used throughout the UI components
-    created_at: createdAtIso,
-    last_updated_at: updatedAtIso,
-    // Provide safe defaults for required fields used by UI
-    access_level: (protoSpace.getAccessLevel?.() || 'private') as Space['access_level'],
-    document_count: typeof contentCount === 'number' ? contentCount : 0,
-    total_size_bytes: protoSpace.getTotalSizeBytes?.() || 0,
-    // Optional stats mirrored for components that already read these
+    keywords: [],
+    accessLevel: 'private' as Space['accessLevel'],
+    createdAt: createdAtIso,
+    lastUpdatedAt: updatedAtIso,
+    documentCount: typeof contentCount === 'number' ? contentCount : 0,
+    totalSizeBytes: 0,
     contentCount,
-    userCount: stats?.getLinkCount?.() || 0,
+    userCount: linkCount,
   };
 }
 
 // Helper function to convert proto ContentSource to our TypeScript ContentSource type
 function protoContentSourceToContentSource(protoSource: any): ContentSource {
+  const statusMap: Record<number, ContentSource['processingStatus']> = {
+    0: 'pending',
+    1: 'processing', 
+    2: 'completed',
+    3: 'failed'
+  };
+  
+  const status = protoSource.getStatus();
+  const processingStatus = statusMap[status] || 'pending';
+  
   return {
     id: protoSource.getId(),
     spaceId: protoSource.getSpaceId(),
-    name: protoSource.getName(),
-    type: protoSource.getType(),
-    url: protoSource.getUrl() || undefined,
-    size: protoSource.getSize() || undefined,
-    mimeType: protoSource.getMimeType() || undefined,
-    status: protoSource.getStatus(),
+    title: protoSource.getTitle() || undefined,
+    mimeType: protoSource.getMimeType() || '',
+    sizeBytes: protoSource.getSizeBytes() || 0,
+    processingStatus,
+    sourceType: 'file',
     createdAt: timestampToISOString(protoSource.getCreatedAt?.()),
     updatedAt: timestampToISOString(protoSource.getUpdatedAt?.()),
+    contentSummary: protoSource.getContentSummary() || undefined,
   };
 }
 
@@ -142,7 +149,6 @@ export async function searchSpaces(filters?: SpaceFilters): Promise<ActionResult
           });
         } else {
           const spaces = response.getItemsList().map(protoSpaceToSpace);
-          const nextToken = response.getNextPageToken?.() || '';
           resolve({
             ok: true,
             data: {
@@ -220,7 +226,7 @@ export async function getSpace(spaceId: string): Promise<ActionResult<Space>> {
  */
 export async function createSpace(input: CreateSpaceInput): Promise<ActionResult<Space>> {
   try {
-    const { userId, getToken } = await auth();
+    const { userId } = await auth();
     if (!userId) {
       return {
         ok: false,
@@ -289,18 +295,17 @@ export async function updateSpace(spaceId: string, input: UpdateSpaceInput): Pro
     
     request.setId(spaceId);
     
+    // Create a Space object with the fields to update
+    const space = new knowledge.Space();
+    
     if (input.title !== undefined) {
-      request.setTitle(input.title);
+      space.setTitle(input.title);
     }
     if (input.description !== undefined) {
-      request.setDescription(input.description);
+      space.setDescription(input.description);
     }
-    if (input.keywords !== undefined) {
-      request.setKeywordsList(input.keywords);
-    }
-    if (input.icon !== undefined) {
-      request.setIcon(input.icon);
-    }
+    
+    request.setSpace(space);
 
     const metadata = await createMetadataWithAuth();
     return new Promise((resolve) => {
@@ -467,7 +472,7 @@ export async function createUploadURL(input: CreateUploadURLRequest): Promise<Ac
             ok: true,
             data: {
               uploadUrl: response.getUploadUrl(),
-              contentSourceId: response.getContentSourceId(),
+              contentSourceId: response.getContentSource()?.getId() || '',
               expiresAt: timestampToISOString(response.getExpiresAt?.()),
             }
           });

--- a/frontend/src/app/spaces/components/ListView.tsx
+++ b/frontend/src/app/spaces/components/ListView.tsx
@@ -29,7 +29,7 @@ interface ListViewProps {
   loading?: boolean;
 }
 
-type SortKey = 'title' | 'document_count' | 'created_at' | 'last_updated_at';
+type SortKey = 'title' | 'documentCount' | 'createdAt' | 'lastUpdatedAt';
 
 export default function ListView({
   spaces: initialSpaces,
@@ -85,7 +85,7 @@ export default function ListView({
       setSpaces(prevSpaces =>
         prevSpaces.map(space =>
           space.id === spaceId
-            ? { ...space, [editedField]: editedValue, last_updated_at: new Date() }
+            ? { ...space, [editedField]: editedValue, lastUpdatedAt: new Date() }
             : space
         )
       );
@@ -200,32 +200,32 @@ export default function ListView({
                   <TableHead>Keywords</TableHead>
                   <TableHead className="min-w-[200px]">Description</TableHead>
                   <TableHead
-                    onClick={() => requestSort('document_count')}
+                    onClick={() => requestSort('documentCount')}
                     className="cursor-pointer hover:bg-gray-100 transition-colors text-center"
                   >
                     <div className="flex items-center justify-center gap-2">
                       <FileText className="h-4 w-4" />
                       Documents
-                      {getSortIcon('document_count')}
+                      {getSortIcon('documentCount')}
                     </div>
                   </TableHead>
                   <TableHead
-                    onClick={() => requestSort('created_at')}
+                    onClick={() => requestSort('createdAt')}
                     className="cursor-pointer hover:bg-gray-100 transition-colors"
                   >
                     <div className="flex items-center gap-2">
                       <Calendar className="h-4 w-4" />
                       Created
-                      {getSortIcon('created_at')}
+                      {getSortIcon('createdAt')}
                     </div>
                   </TableHead>
                   <TableHead
-                    onClick={() => requestSort('last_updated_at')}
+                    onClick={() => requestSort('lastUpdatedAt')}
                     className="cursor-pointer hover:bg-gray-100 transition-colors"
                   >
                     <div className="flex items-center gap-2">
                       Updated
-                      {getSortIcon('last_updated_at')}
+                      {getSortIcon('lastUpdatedAt')}
                     </div>
                   </TableHead>
                   <TableHead>Access</TableHead>
@@ -323,7 +323,7 @@ export default function ListView({
                       <Dialog>
                         <DialogTrigger asChild>
                           <Button variant="ghost" className="h-8 px-2 text-blue-600 hover:text-blue-800 hover:bg-blue-50">
-                            {space.document_count || 0}
+                            {space.documentCount || 0}
                           </Button>
                         </DialogTrigger>
                         <DialogContent>
@@ -342,23 +342,23 @@ export default function ListView({
 
                     <TableCell>
                       <span className="text-sm text-gray-500">
-                        {formatDate(space.created_at)}
+                        {formatDate(space.createdAt)}
                       </span>
                     </TableCell>
 
                     <TableCell>
                       <span className="text-sm text-gray-500">
-                        {formatDate(space.last_updated_at)}
+                        {formatDate(space.lastUpdatedAt)}
                       </span>
                     </TableCell>
 
                     <TableCell>
                       <Badge
                         variant="secondary"
-                        className={`text-xs capitalize ${getAccessColor(space.access_level)} flex items-center gap-1 w-fit`}
+                        className={`text-xs capitalize ${getAccessColor(space.accessLevel)} flex items-center gap-1 w-fit`}
                       >
-                        {getAccessIcon(space.access_level)}
-                        {space.access_level}
+                        {getAccessIcon(space.accessLevel)}
+                        {space.accessLevel}
                       </Badge>
                     </TableCell>
 

--- a/frontend/src/app/spaces/components/SpaceCard.tsx
+++ b/frontend/src/app/spaces/components/SpaceCard.tsx
@@ -29,7 +29,7 @@ export default function SpaceCard({
   const stats = 'stats' in space ? space.stats : undefined;
   
   const getAccessIcon = () => {
-    switch (space.access_level) {
+    switch (space.accessLevel) {
       case 'public': return <Globe className="h-3 w-3" />;
       case 'shared': return <Users className="h-3 w-3" />;
       case 'private': return <Lock className="h-3 w-3" />;
@@ -46,10 +46,8 @@ export default function SpaceCard({
     }
   };
 
-  const formatDate = (date: Date | string | undefined | null) => {
-    if (!date) return '—';
+  const formatDate = (date: Date | string) => {
     const d = typeof date === 'string' ? new Date(date) : date;
-    if (!(d instanceof Date) || isNaN(d.getTime())) return '—';
     return d.toLocaleDateString();
   };
 
@@ -95,16 +93,16 @@ export default function SpaceCard({
                 className={`text-xs capitalize ${getAccessColor()} flex items-center gap-1`}
               >
                 {getAccessIcon()}
-                {space.access_level}
+                {space.accessLevel}
               </Badge>
             </div>
 
             <div className="block cursor-pointer" onClick={() => onSelect?.(space.id)}>
               {/* Cover Image */}
               <div className="relative h-48 w-full">
-                {space.cover_image ? (
+                {space.coverImage ? (
                   <Image
-                    src={space.cover_image}
+                    src={space.coverImage}
                     alt={space.title}
                     fill
                     className="object-cover transition-transform duration-200 group-hover:scale-105"
@@ -151,16 +149,16 @@ export default function SpaceCard({
                   <div className="flex items-center justify-between text-xs text-gray-500">
                     <div className="flex items-center gap-1">
                       <Calendar className="h-3 w-3" />
-                      <span>{formatDate(space.created_at)}</span>
+                      <span>{formatDate(space.createdAt)}</span>
                     </div>
                     <div className="flex items-center gap-1">
                       <FileText className="h-3 w-3" />
-                      <span>{space.document_count || stats?.contentCount || space.contentCount || 0} docs</span>
+                      <span>{space.documentCount || stats?.contentCount || space.contentCount || 0} docs</span>
                     </div>
                   </div>
                   
                   <div className="text-xs text-gray-400">
-                    Last updated: {formatDate(space.last_updated_at)}
+                    Last updated: {formatDate(space.lastUpdatedAt)}
                   </div>
                 </div>
               </div>
@@ -176,7 +174,7 @@ export default function SpaceCard({
               <p className="text-xs text-gray-300">{space.keywords.join(', ')}</p>
             </div>
             <div className="text-xs">
-              <p>Size: {formatSize(space.total_size_bytes || 0)} MB</p>
+              <p>Size: {formatSize(space.totalSizeBytes || 0)} MB</p>
             </div>
           </div>
         </TooltipContent>

--- a/frontend/src/app/spaces/types/canvas.ts
+++ b/frontend/src/app/spaces/types/canvas.ts
@@ -4,19 +4,19 @@
 // Core canvas data structure
 export interface CanvasData {
   id: string
-  space_id: string
+  spaceId: string
   nodes: CanvasNode[]
   connections: CanvasConnection[]
   layout: CanvasLayout
   metadata?: CanvasMetadata
-  created_at: Date | string
-  updated_at: Date | string
+  createdAt: Date | string
+  updatedAt: Date | string
 }
 
 // Canvas node representing content or concepts
 export interface CanvasNode {
   id: string
-  canvas_id: string
+  canvasId: string
   type: 'document' | 'concept' | 'note' | 'cluster'
   title: string
   content?: string
@@ -26,39 +26,39 @@ export interface CanvasNode {
   metadata?: Record<string, any>
   
   // Relationships to content sources (from Knowledge microservice)
-  content_source_id?: string
+  contentSourceId?: string
   
   // Node state
   locked?: boolean
   visible?: boolean
   selected?: boolean
   
-  created_at: Date | string
-  updated_at: Date | string
+  createdAt: Date | string
+  updatedAt: Date | string
 }
 
 // Canvas connection between nodes
 export interface CanvasConnection {
   id: string
-  canvas_id: string
-  source_node_id: string
-  target_node_id: string
+  canvasId: string
+  sourceNodeId: string
+  targetNodeId: string
   type: 'reference' | 'similarity' | 'custom' | 'hierarchy'
   strength: number
   label?: string
   style?: CanvasConnectionStyle
   metadata?: Record<string, any>
   
-  created_at: Date | string
-  updated_at: Date | string
+  createdAt: Date | string
+  updatedAt: Date | string
 }
 
 // Canvas layout configuration
 export interface CanvasLayout {
   type: 'force' | 'hierarchical' | 'circular' | 'custom' | 'manual'
-  algorithm_settings: Record<string, any>
+  algorithmSettings: Record<string, any>
   viewport: CanvasViewport
-  grid_settings?: CanvasGridSettings
+  gridSettings?: CanvasGridSettings
 }
 
 // Supporting types for canvas elements
@@ -103,7 +103,7 @@ export interface CanvasGridSettings {
   size: number
   color?: string
   opacity?: number
-  snap_to_grid?: boolean
+  snapToGrid?: boolean
 }
 
 export interface CanvasMetadata {
@@ -117,7 +117,7 @@ export interface CanvasMetadata {
 // Canvas operations and interactions
 export interface CanvasOperation {
   id: string
-  canvas_id: string
+  canvasId: string
   type: 'create_node' | 'update_node' | 'delete_node' | 'create_connection' | 'delete_connection' | 'layout_change'
   data: Record<string, any>
   user_id?: string
@@ -126,52 +126,52 @@ export interface CanvasOperation {
 
 // Canvas collaboration (for real-time editing)
 export interface CanvasCollaborator {
-  user_id: string
-  cursor_position?: CanvasPosition
-  selected_nodes?: string[]
+  userId: string
+  cursorPosition?: CanvasPosition
+  selectedNodes?: string[]
   active: boolean
-  last_seen: Date | string
+  lastSeen: Date | string
 }
 
 // Canvas API request/response types
 export interface CreateCanvasRequest {
-  space_id: string
-  layout_type?: CanvasLayout['type']
-  initial_nodes?: Omit<CanvasNode, 'id' | 'canvas_id' | 'created_at' | 'updated_at'>[]
+  spaceId: string
+  layoutType?: CanvasLayout['type']
+  initialNodes?: Omit<CanvasNode, 'id' | 'canvasId' | 'createdAt' | 'updatedAt'>[]
 }
 
 export interface UpdateCanvasLayoutRequest {
-  canvas_id: string
+  canvasId: string
   layout: CanvasLayout
 }
 
 export interface CreateNodeRequest {
-  canvas_id: string
-  node: Omit<CanvasNode, 'id' | 'canvas_id' | 'created_at' | 'updated_at'>
+  canvasId: string
+  node: Omit<CanvasNode, 'id' | 'canvasId' | 'createdAt' | 'updatedAt'>
 }
 
 export interface UpdateNodeRequest {
-  node_id: string
+  nodeId: string
   updates: Partial<Pick<CanvasNode, 'title' | 'content' | 'position' | 'size' | 'style' | 'metadata'>>
 }
 
 export interface CreateConnectionRequest {
-  canvas_id: string
-  connection: Omit<CanvasConnection, 'id' | 'canvas_id' | 'created_at' | 'updated_at'>
+  canvasId: string
+  connection: Omit<CanvasConnection, 'id' | 'canvasId' | 'createdAt' | 'updatedAt'>
 }
 
 // Canvas UI state (for frontend components)
 export interface CanvasUIState {
-  canvas_id: string | null
+  canvasId: string | null
   viewport: CanvasViewport
-  selected_nodes: string[]
-  selected_connections: string[]
-  tool_mode: 'select' | 'pan' | 'create_node' | 'create_connection'
-  is_loading: boolean
-  is_saving: boolean
-  show_grid: boolean
-  show_minimap: boolean
-  collaboration_active: boolean
+  selectedNodes: string[]
+  selectedConnections: string[]
+  toolMode: 'select' | 'pan' | 'create_node' | 'create_connection'
+  isLoading: boolean
+  isSaving: boolean
+  showGrid: boolean
+  showMinimap: boolean
+  collaborationActive: boolean
   collaborators: CanvasCollaborator[]
 }
 
@@ -182,13 +182,13 @@ export interface CanvasViewerProps {
   readonly?: boolean
   onNodeSelect?: (nodeIds: string[]) => void
   onNodeUpdate?: (nodeId: string, updates: Partial<CanvasNode>) => void
-  onConnectionCreate?: (connection: Omit<CanvasConnection, 'id' | 'canvas_id' | 'created_at' | 'updated_at'>) => void
+  onConnectionCreate?: (connection: Omit<CanvasConnection, 'id' | 'canvasId' | 'createdAt' | 'updatedAt'>) => void
   onLayoutChange?: (layout: CanvasLayout) => void
 }
 
 export interface CanvasToolbarProps {
   canvasState: CanvasUIState
-  onToolChange: (tool: CanvasUIState['tool_mode']) => void
+  onToolChange: (tool: CanvasUIState['toolMode']) => void
   onLayoutChange: (layoutType: CanvasLayout['type']) => void
   onZoomChange: (zoom: number) => void
   onToggleGrid: () => void
@@ -197,10 +197,10 @@ export interface CanvasToolbarProps {
 
 // Canvas integration with Knowledge microservice
 export interface CanvasContentSourceLink {
-  canvas_node_id: string
-  content_source_id: string
-  link_type: 'represents' | 'references' | 'derived_from'
-  created_at: Date | string
+  canvasNodeId: string
+  contentSourceId: string
+  linkType: 'represents' | 'references' | 'derived_from'
+  createdAt: Date | string
 }
 
 // Error types specific to Canvas operations
@@ -208,9 +208,9 @@ export interface CanvasError {
   type: 'canvas_not_found' | 'node_not_found' | 'connection_invalid' | 'layout_failed' | 'permission_denied'
   message: string
   code: string
-  canvas_id?: string
-  node_id?: string
-  connection_id?: string
+  canvasId?: string
+  nodeId?: string
+  connectionId?: string
 }
 
 // Constants for Canvas service
@@ -226,4 +226,4 @@ export const CANVAS_CONSTANTS = {
 export type CanvasNodeType = CanvasNode['type']
 export type CanvasConnectionType = CanvasConnection['type']
 export type CanvasLayoutType = CanvasLayout['type']
-export type CanvasToolMode = CanvasUIState['tool_mode']
+export type CanvasToolMode = CanvasUIState['toolMode']

--- a/frontend/src/app/spaces/types/canvas.ts
+++ b/frontend/src/app/spaces/types/canvas.ts
@@ -1,21 +1,19 @@
+import type { BaseEntity } from './shared'
+
 // Canvas-related types for the Canvas Microservice
 // These types define the minimal necessary structure for future Canvas service implementation
 
 // Core canvas data structure
-export interface CanvasData {
-  id: string
+export interface CanvasData extends BaseEntity {
   spaceId: string
   nodes: CanvasNode[]
   connections: CanvasConnection[]
   layout: CanvasLayout
   metadata?: CanvasMetadata
-  createdAt: Date | string
-  updatedAt: Date | string
 }
 
 // Canvas node representing content or concepts
-export interface CanvasNode {
-  id: string
+export interface CanvasNode extends BaseEntity {
   canvasId: string
   type: 'document' | 'concept' | 'note' | 'cluster'
   title: string
@@ -32,14 +30,10 @@ export interface CanvasNode {
   locked?: boolean
   visible?: boolean
   selected?: boolean
-  
-  createdAt: Date | string
-  updatedAt: Date | string
 }
 
 // Canvas connection between nodes
-export interface CanvasConnection {
-  id: string
+export interface CanvasConnection extends BaseEntity {
   canvasId: string
   sourceNodeId: string
   targetNodeId: string
@@ -48,9 +42,6 @@ export interface CanvasConnection {
   label?: string
   style?: CanvasConnectionStyle
   metadata?: Record<string, any>
-  
-  createdAt: Date | string
-  updatedAt: Date | string
 }
 
 // Canvas layout configuration
@@ -115,12 +106,11 @@ export interface CanvasMetadata {
 }
 
 // Canvas operations and interactions
-export interface CanvasOperation {
-  id: string
+export interface CanvasOperation extends BaseEntity {
   canvasId: string
   type: 'create_node' | 'update_node' | 'delete_node' | 'create_connection' | 'delete_connection' | 'layout_change'
   data: Record<string, any>
-  user_id?: string
+  userId?: string
   timestamp: Date | string
 }
 
@@ -196,11 +186,10 @@ export interface CanvasToolbarProps {
 }
 
 // Canvas integration with Knowledge microservice
-export interface CanvasContentSourceLink {
+export interface CanvasContentSourceLink extends Omit<BaseEntity, 'updatedAt'> {
   canvasNodeId: string
   contentSourceId: string
   linkType: 'represents' | 'references' | 'derived_from'
-  createdAt: Date | string
 }
 
 // Error types specific to Canvas operations

--- a/frontend/src/app/spaces/types/canvas.ts
+++ b/frontend/src/app/spaces/types/canvas.ts
@@ -1,0 +1,229 @@
+// Canvas-related types for the Canvas Microservice
+// These types define the minimal necessary structure for future Canvas service implementation
+
+// Core canvas data structure
+export interface CanvasData {
+  id: string
+  space_id: string
+  nodes: CanvasNode[]
+  connections: CanvasConnection[]
+  layout: CanvasLayout
+  metadata?: CanvasMetadata
+  created_at: Date | string
+  updated_at: Date | string
+}
+
+// Canvas node representing content or concepts
+export interface CanvasNode {
+  id: string
+  canvas_id: string
+  type: 'document' | 'concept' | 'note' | 'cluster'
+  title: string
+  content?: string
+  position: CanvasPosition
+  size: CanvasSize
+  style?: CanvasNodeStyle
+  metadata?: Record<string, any>
+  
+  // Relationships to content sources (from Knowledge microservice)
+  content_source_id?: string
+  
+  // Node state
+  locked?: boolean
+  visible?: boolean
+  selected?: boolean
+  
+  created_at: Date | string
+  updated_at: Date | string
+}
+
+// Canvas connection between nodes
+export interface CanvasConnection {
+  id: string
+  canvas_id: string
+  source_node_id: string
+  target_node_id: string
+  type: 'reference' | 'similarity' | 'custom' | 'hierarchy'
+  strength: number
+  label?: string
+  style?: CanvasConnectionStyle
+  metadata?: Record<string, any>
+  
+  created_at: Date | string
+  updated_at: Date | string
+}
+
+// Canvas layout configuration
+export interface CanvasLayout {
+  type: 'force' | 'hierarchical' | 'circular' | 'custom' | 'manual'
+  algorithm_settings: Record<string, any>
+  viewport: CanvasViewport
+  grid_settings?: CanvasGridSettings
+}
+
+// Supporting types for canvas elements
+export interface CanvasPosition {
+  x: number
+  y: number
+  z?: number // For 3D layouts in the future
+}
+
+export interface CanvasSize {
+  width: number
+  height: number
+}
+
+export interface CanvasViewport {
+  center: CanvasPosition
+  zoom: number
+  rotation?: number
+}
+
+export interface CanvasNodeStyle {
+  backgroundColor?: string
+  borderColor?: string
+  borderWidth?: number
+  borderRadius?: number
+  fontSize?: number
+  fontColor?: string
+  opacity?: number
+  shadow?: boolean
+}
+
+export interface CanvasConnectionStyle {
+  color?: string
+  width?: number
+  style?: 'solid' | 'dashed' | 'dotted'
+  arrowType?: 'none' | 'arrow' | 'circle'
+  opacity?: number
+}
+
+export interface CanvasGridSettings {
+  enabled: boolean
+  size: number
+  color?: string
+  opacity?: number
+  snap_to_grid?: boolean
+}
+
+export interface CanvasMetadata {
+  version: string
+  last_layout_algorithm?: string
+  auto_layout_enabled?: boolean
+  collaboration_enabled?: boolean
+  view_mode?: 'edit' | 'view' | 'present'
+}
+
+// Canvas operations and interactions
+export interface CanvasOperation {
+  id: string
+  canvas_id: string
+  type: 'create_node' | 'update_node' | 'delete_node' | 'create_connection' | 'delete_connection' | 'layout_change'
+  data: Record<string, any>
+  user_id?: string
+  timestamp: Date | string
+}
+
+// Canvas collaboration (for real-time editing)
+export interface CanvasCollaborator {
+  user_id: string
+  cursor_position?: CanvasPosition
+  selected_nodes?: string[]
+  active: boolean
+  last_seen: Date | string
+}
+
+// Canvas API request/response types
+export interface CreateCanvasRequest {
+  space_id: string
+  layout_type?: CanvasLayout['type']
+  initial_nodes?: Omit<CanvasNode, 'id' | 'canvas_id' | 'created_at' | 'updated_at'>[]
+}
+
+export interface UpdateCanvasLayoutRequest {
+  canvas_id: string
+  layout: CanvasLayout
+}
+
+export interface CreateNodeRequest {
+  canvas_id: string
+  node: Omit<CanvasNode, 'id' | 'canvas_id' | 'created_at' | 'updated_at'>
+}
+
+export interface UpdateNodeRequest {
+  node_id: string
+  updates: Partial<Pick<CanvasNode, 'title' | 'content' | 'position' | 'size' | 'style' | 'metadata'>>
+}
+
+export interface CreateConnectionRequest {
+  canvas_id: string
+  connection: Omit<CanvasConnection, 'id' | 'canvas_id' | 'created_at' | 'updated_at'>
+}
+
+// Canvas UI state (for frontend components)
+export interface CanvasUIState {
+  canvas_id: string | null
+  viewport: CanvasViewport
+  selected_nodes: string[]
+  selected_connections: string[]
+  tool_mode: 'select' | 'pan' | 'create_node' | 'create_connection'
+  is_loading: boolean
+  is_saving: boolean
+  show_grid: boolean
+  show_minimap: boolean
+  collaboration_active: boolean
+  collaborators: CanvasCollaborator[]
+}
+
+// Canvas component props (for React components)
+export interface CanvasViewerProps {
+  spaceId: string
+  canvasData?: CanvasData
+  readonly?: boolean
+  onNodeSelect?: (nodeIds: string[]) => void
+  onNodeUpdate?: (nodeId: string, updates: Partial<CanvasNode>) => void
+  onConnectionCreate?: (connection: Omit<CanvasConnection, 'id' | 'canvas_id' | 'created_at' | 'updated_at'>) => void
+  onLayoutChange?: (layout: CanvasLayout) => void
+}
+
+export interface CanvasToolbarProps {
+  canvasState: CanvasUIState
+  onToolChange: (tool: CanvasUIState['tool_mode']) => void
+  onLayoutChange: (layoutType: CanvasLayout['type']) => void
+  onZoomChange: (zoom: number) => void
+  onToggleGrid: () => void
+  onToggleMinimap: () => void
+}
+
+// Canvas integration with Knowledge microservice
+export interface CanvasContentSourceLink {
+  canvas_node_id: string
+  content_source_id: string
+  link_type: 'represents' | 'references' | 'derived_from'
+  created_at: Date | string
+}
+
+// Error types specific to Canvas operations
+export interface CanvasError {
+  type: 'canvas_not_found' | 'node_not_found' | 'connection_invalid' | 'layout_failed' | 'permission_denied'
+  message: string
+  code: string
+  canvas_id?: string
+  node_id?: string
+  connection_id?: string
+}
+
+// Constants for Canvas service
+export const CANVAS_CONSTANTS = {
+  MAX_NODES_PER_CANVAS: 1000,
+  MAX_CONNECTIONS_PER_CANVAS: 5000,
+  MIN_ZOOM: 0.1,
+  MAX_ZOOM: 5.0,
+  DEFAULT_NODE_SIZE: { width: 200, height: 100 },
+  DEFAULT_VIEWPORT: { center: { x: 0, y: 0 }, zoom: 1.0 }
+} as const
+
+export type CanvasNodeType = CanvasNode['type']
+export type CanvasConnectionType = CanvasConnection['type']
+export type CanvasLayoutType = CanvasLayout['type']
+export type CanvasToolMode = CanvasUIState['tool_mode']

--- a/frontend/src/app/spaces/types/content.ts
+++ b/frontend/src/app/spaces/types/content.ts
@@ -1,64 +1,42 @@
-// Content Sources types for the Knowledge Microservice (content_sources DB)
-// This handles all content upload, processing, and management functionality
-export interface ContentSource {
-  id: string
+import type { 
+  BaseEntity,
+  ContentSourceType,
+  ContentSourceStatus,
+  ErrorState,
+  ContentMetadata,
+  ProcessingMetadata
+} from './shared'
+
+// =========================================================================
+// CONTENT SOURCE INTERFACES
+// =========================================================================
+
+export interface ContentSource extends BaseEntity, ContentMetadata {
   spaceId: string
-  filename?: string
-  title?: string
-  mimeType: string
-  sizeBytes: number
-  uploadUrl?: string
-  processingStatus: 'pending' | 'processing' | 'completed' | 'failed'
-  createdAt: Date | string
-  updatedAt: Date | string
-  
-  // Content-specific fields
-  sourceType: 'file' | 'url' | 'text' | 'google_drive'
+  sourceType: ContentSourceType
+  processingStatus: ContentSourceStatus
   sourceMetadata?: Record<string, any>
-  extractedText?: string
-  thumbnailUrl?: string
-  
-  // Processing details
   processingError?: string
   processingStartedAt?: Date | string
   processingCompletedAt?: Date | string
-  
-  // Content analysis results
-  contentSummary?: string
-  detectedLanguage?: string
-  wordCount?: number
-  pageCount?: number
+  uploadUrl?: string
 }
 
-export enum ContentSourceType {
-  UNKNOWN = 'UNKNOWN',
-  URL = 'URL',
-  FILE = 'FILE',
-  TEXT = 'TEXT'
-}
+// =========================================================================
+// UPLOAD MANAGEMENT
+// =========================================================================
 
-export enum ContentSourceStatus {
-  PENDING = 'PENDING',
-  PROCESSING = 'PROCESSING',
-  COMPLETED = 'COMPLETED',
-  FAILED = 'FAILED'
-}
-
-// Upload management types (Knowledge microservice - content_sources DB)
-export interface UploadSession {
-  id: string
+export interface UploadSession extends BaseEntity {
   spaceId: string
   files: UploadFile[]
   status: 'active' | 'completed' | 'cancelled'
-  createdAt: Date | string
   completedAt?: Date | string
   totalFiles: number
   completedFiles: number
   failedFiles: number
 }
 
-export interface UploadFile {
-  id: string
+export interface UploadFile extends BaseEntity {
   sessionId: string
   filename: string
   sizeBytes: number
@@ -72,7 +50,6 @@ export interface UploadFile {
   completedAt?: Date | string
 }
 
-// Upload progress tracking
 export interface UploadProgress {
   fileId: string
   filename: string
@@ -84,19 +61,19 @@ export interface UploadProgress {
   estimatedTimeRemaining?: number
 }
 
-// Processing status for real-time updates
-export interface ProcessingStatus {
+export interface ProcessingStatus extends ProcessingMetadata {
   contentId: string
-  status: 'pending' | 'processing' | 'completed' | 'failed'
-  progress: number
-  stage: 'upload' | 'extraction' | 'analysis' | 'indexing' | 'complete'
+  status: ContentSourceStatus
   message?: string
   error?: string
   startedAt?: Date | string
   completedAt?: Date | string
 }
 
-// Upload-related server action types
+// =========================================================================
+// API REQUEST/RESPONSE TYPES
+// =========================================================================
+
 export interface CreateUploadSessionRequest {
   spaceId: string
   files: {
@@ -142,7 +119,21 @@ export interface DeleteContentSourceRequest {
   spaceId: string
 }
 
-// Google Drive integration types
+export interface CreateUploadURLRequest {
+  spaceId: string
+  filename: string
+  mimeType: string
+  sizeBytes: number
+}
+
+export interface CreateUploadURLResponse {
+  uploadUrl: string
+  contentSourceId: string
+  expiresAt: string
+}
+
+// =========================================================================\n// GOOGLE DRIVE INTEGRATION\n// =========================================================================
+
 export interface GoogleDriveFile {
   id: string
   name: string
@@ -171,7 +162,8 @@ export interface ImportGoogleDriveFileRequest {
   mimeType: string
 }
 
-// Content-related component prop types
+// =========================================================================\n// COMPONENT PROPS\n// =========================================================================
+
 export interface ContentSourceCardProps {
   contentSource: ContentSource
   onView: (contentSource: ContentSource) => void
@@ -196,9 +188,8 @@ export interface ProcessingStatusProps {
   onCancel?: () => void
 }
 
+// =========================================================================\n// UI STATE\n// =========================================================================
 
-
-// Upload modal UI state
 export interface UploadModalState {
   isOpen: boolean
   spaceId: string | null
@@ -210,27 +201,14 @@ export interface UploadModalState {
   isUploading: boolean
 }
 
-// Import error types from spaces.ts
-export interface UploadError {
-  type: 'validation' | 'network' | 'server' | 'processing' | 'authentication' | 'permission'
-  message: string
-  code: string
-  retryable: boolean
-  actions?: ErrorAction[]
-  details?: Record<string, any>
+export interface UploadError extends ErrorState {
   fileId?: string
   filename?: string
   uploadProgress?: number
 }
 
-export interface ErrorAction {
-  label: string
-  action: () => void | Promise<void>
-  variant: 'primary' | 'secondary' | 'destructive'
-  loading?: boolean
-}
+// =========================================================================\n// CONSTANTS\n// =========================================================================
 
-// File type validation constants
 export const SUPPORTED_FILE_TYPES = {
   'application/pdf': '.pdf',
   'text/plain': '.txt',
@@ -246,4 +224,8 @@ export type SupportedMimeType = keyof typeof SUPPORTED_FILE_TYPES
 
 export const MAX_FILE_SIZE = 100 * 1024 * 1024 // 100MB
 export const MAX_FILES_PER_UPLOAD = 10
-export const UPLOAD_CHUNK_SIZE = 5 * 1024 * 1024 // 5MB chunks for large file uploads
+export const UPLOAD_CHUNK_SIZE = 5 * 1024 * 1024 // 5MB chunks
+
+// =========================================================================\n// RE-EXPORT SHARED TYPES\n// =========================================================================
+
+export { ContentSourceType, ContentSourceStatus } from './shared'

--- a/frontend/src/app/spaces/types/content.ts
+++ b/frontend/src/app/spaces/types/content.ts
@@ -1,0 +1,249 @@
+// Content Sources types for the Knowledge Microservice (content_sources DB)
+// This handles all content upload, processing, and management functionality
+export interface ContentSource {
+  id: string
+  space_id: string
+  filename?: string
+  title?: string
+  mime_type: string
+  size_bytes: number
+  upload_url?: string
+  processing_status: 'pending' | 'processing' | 'completed' | 'failed'
+  created_at: Date | string
+  updated_at: Date | string
+  
+  // Content-specific fields
+  source_type: 'file' | 'url' | 'text' | 'google_drive'
+  source_metadata?: Record<string, any>
+  extracted_text?: string
+  thumbnail_url?: string
+  
+  // Processing details
+  processing_error?: string
+  processing_started_at?: Date | string
+  processing_completed_at?: Date | string
+  
+  // Content analysis results
+  content_summary?: string
+  detected_language?: string
+  word_count?: number
+  page_count?: number
+}
+
+export enum ContentSourceType {
+  UNKNOWN = 'UNKNOWN',
+  URL = 'URL',
+  FILE = 'FILE',
+  TEXT = 'TEXT'
+}
+
+export enum ContentSourceStatus {
+  PENDING = 'PENDING',
+  PROCESSING = 'PROCESSING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED'
+}
+
+// Upload management types (Knowledge microservice - content_sources DB)
+export interface UploadSession {
+  id: string
+  space_id: string
+  files: UploadFile[]
+  status: 'active' | 'completed' | 'cancelled'
+  created_at: Date | string
+  completed_at?: Date | string
+  total_files: number
+  completed_files: number
+  failed_files: number
+}
+
+export interface UploadFile {
+  id: string
+  session_id: string
+  filename: string
+  size_bytes: number
+  mime_type: string
+  upload_url?: string
+  progress: number
+  status: 'pending' | 'uploading' | 'processing' | 'completed' | 'failed'
+  error_message?: string
+  content_source_id?: string
+  started_at?: Date | string
+  completed_at?: Date | string
+}
+
+// Upload progress tracking
+export interface UploadProgress {
+  fileId: string
+  filename: string
+  progress: number
+  status: 'uploading' | 'processing' | 'completed' | 'failed'
+  bytesUploaded: number
+  totalBytes: number
+  uploadSpeed?: number
+  estimatedTimeRemaining?: number
+}
+
+// Processing status for real-time updates
+export interface ProcessingStatus {
+  contentId: string
+  status: 'pending' | 'processing' | 'completed' | 'failed'
+  progress: number
+  stage: 'upload' | 'extraction' | 'analysis' | 'indexing' | 'complete'
+  message?: string
+  error?: string
+  startedAt?: Date | string
+  completedAt?: Date | string
+}
+
+// Upload-related server action types
+export interface CreateUploadSessionRequest {
+  spaceId: string
+  files: {
+    filename: string
+    mimeType: string
+    sizeBytes: number
+  }[]
+}
+
+export interface CreateUploadSessionResponse {
+  sessionId: string
+  uploadUrls: {
+    fileId: string
+    filename: string
+    uploadUrl: string
+    expiresAt: string
+  }[]
+}
+
+export interface ConfirmUploadRequest {
+  sessionId: string
+  fileId: string
+  success: boolean
+  error?: string
+}
+
+export interface CreateContentSourceFromUrlRequest {
+  spaceId: string
+  url: string
+  title?: string
+  description?: string
+}
+
+export interface CreateContentSourceFromTextRequest {
+  spaceId: string
+  title: string
+  content: string
+  format?: 'plain' | 'markdown' | 'html'
+}
+
+export interface DeleteContentSourceRequest {
+  contentSourceId: string
+  spaceId: string
+}
+
+// Google Drive integration types
+export interface GoogleDriveFile {
+  id: string
+  name: string
+  mimeType: string
+  size: number
+  thumbnailLink?: string
+  webViewLink: string
+  downloadUrl?: string
+  parents: string[]
+  createdTime: string
+  modifiedTime: string
+}
+
+export interface GoogleDriveAuthState {
+  isAuthenticated: boolean
+  accessToken?: string
+  refreshToken?: string
+  expiresAt?: Date
+  userEmail?: string
+}
+
+export interface ImportGoogleDriveFileRequest {
+  spaceId: string
+  fileId: string
+  filename: string
+  mimeType: string
+}
+
+// Content-related component prop types
+export interface ContentSourceCardProps {
+  contentSource: ContentSource
+  onView: (contentSource: ContentSource) => void
+  onDownload: (contentSource: ContentSource) => void
+  onDelete: (contentSource: ContentSource) => void
+  isDeleting?: boolean
+  showProcessingStatus?: boolean
+}
+
+export interface UploadModalProps {
+  isOpen: boolean
+  spaceId: string
+  onClose: () => void
+  onUploadComplete: (contentSources: ContentSource[]) => void
+  autoOpenTab?: 'file' | 'google-drive' | 'link' | 'text'
+}
+
+export interface ProcessingStatusProps {
+  status: ProcessingStatus
+  showDetails?: boolean
+  onRetry?: () => void
+  onCancel?: () => void
+}
+
+
+
+// Upload modal UI state
+export interface UploadModalState {
+  isOpen: boolean
+  spaceId: string | null
+  activeTab: 'file' | 'google-drive' | 'link' | 'text'
+  dragActive: boolean
+  files: File[]
+  uploadProgress: Record<string, UploadProgress>
+  errors: UploadError[]
+  isUploading: boolean
+}
+
+// Import error types from spaces.ts
+export interface UploadError {
+  type: 'validation' | 'network' | 'server' | 'processing' | 'authentication' | 'permission'
+  message: string
+  code: string
+  retryable: boolean
+  actions?: ErrorAction[]
+  details?: Record<string, any>
+  fileId?: string
+  filename?: string
+  uploadProgress?: number
+}
+
+export interface ErrorAction {
+  label: string
+  action: () => void | Promise<void>
+  variant: 'primary' | 'secondary' | 'destructive'
+  loading?: boolean
+}
+
+// File type validation constants
+export const SUPPORTED_FILE_TYPES = {
+  'application/pdf': '.pdf',
+  'text/plain': '.txt',
+  'text/markdown': '.md',
+  'audio/mpeg': '.mp3',
+  'audio/wav': '.wav',
+  'audio/mp4': '.m4a',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+  'application/msword': '.doc'
+} as const
+
+export type SupportedMimeType = keyof typeof SUPPORTED_FILE_TYPES
+
+export const MAX_FILE_SIZE = 100 * 1024 * 1024 // 100MB
+export const MAX_FILES_PER_UPLOAD = 10
+export const UPLOAD_CHUNK_SIZE = 5 * 1024 * 1024 // 5MB chunks for large file uploads

--- a/frontend/src/app/spaces/types/content.ts
+++ b/frontend/src/app/spaces/types/content.ts
@@ -2,32 +2,32 @@
 // This handles all content upload, processing, and management functionality
 export interface ContentSource {
   id: string
-  space_id: string
+  spaceId: string
   filename?: string
   title?: string
-  mime_type: string
-  size_bytes: number
-  upload_url?: string
-  processing_status: 'pending' | 'processing' | 'completed' | 'failed'
-  created_at: Date | string
-  updated_at: Date | string
+  mimeType: string
+  sizeBytes: number
+  uploadUrl?: string
+  processingStatus: 'pending' | 'processing' | 'completed' | 'failed'
+  createdAt: Date | string
+  updatedAt: Date | string
   
   // Content-specific fields
-  source_type: 'file' | 'url' | 'text' | 'google_drive'
-  source_metadata?: Record<string, any>
-  extracted_text?: string
-  thumbnail_url?: string
+  sourceType: 'file' | 'url' | 'text' | 'google_drive'
+  sourceMetadata?: Record<string, any>
+  extractedText?: string
+  thumbnailUrl?: string
   
   // Processing details
-  processing_error?: string
-  processing_started_at?: Date | string
-  processing_completed_at?: Date | string
+  processingError?: string
+  processingStartedAt?: Date | string
+  processingCompletedAt?: Date | string
   
   // Content analysis results
-  content_summary?: string
-  detected_language?: string
-  word_count?: number
-  page_count?: number
+  contentSummary?: string
+  detectedLanguage?: string
+  wordCount?: number
+  pageCount?: number
 }
 
 export enum ContentSourceType {
@@ -47,29 +47,29 @@ export enum ContentSourceStatus {
 // Upload management types (Knowledge microservice - content_sources DB)
 export interface UploadSession {
   id: string
-  space_id: string
+  spaceId: string
   files: UploadFile[]
   status: 'active' | 'completed' | 'cancelled'
-  created_at: Date | string
-  completed_at?: Date | string
-  total_files: number
-  completed_files: number
-  failed_files: number
+  createdAt: Date | string
+  completedAt?: Date | string
+  totalFiles: number
+  completedFiles: number
+  failedFiles: number
 }
 
 export interface UploadFile {
   id: string
-  session_id: string
+  sessionId: string
   filename: string
-  size_bytes: number
-  mime_type: string
-  upload_url?: string
+  sizeBytes: number
+  mimeType: string
+  uploadUrl?: string
   progress: number
   status: 'pending' | 'uploading' | 'processing' | 'completed' | 'failed'
-  error_message?: string
-  content_source_id?: string
-  started_at?: Date | string
-  completed_at?: Date | string
+  errorMessage?: string
+  contentSourceId?: string
+  startedAt?: Date | string
+  completedAt?: Date | string
 }
 
 // Upload progress tracking

--- a/frontend/src/app/spaces/types/index.ts
+++ b/frontend/src/app/spaces/types/index.ts
@@ -1,7 +1,25 @@
 // Re-export all types for easier imports
+
+// Shared types and utilities
+export * as Shared from './shared'
+
 // Knowledge Microservice types
 export * as Spaces from './spaces'      // spaces DB
-export * as Content from './content'     // content_sources DB
+export * as Content from './content'    // content_sources DB
 
 // Canvas Microservice types  
 export * as Canvas from './canvas'      // Canvas service (separate microservice)
+
+// Convenience re-exports for commonly used types
+export type { 
+  ErrorState, 
+  ErrorAction, 
+  ValidationError,
+  ApiError,
+  ActionResult,
+  ServerActionResult
+} from './shared'
+
+export type { Space, SpaceWithStats, ViewMode } from './spaces'
+export type { ContentSource, UploadSession } from './content'
+export type { CanvasData, CanvasNode, CanvasConnection } from './canvas'

--- a/frontend/src/app/spaces/types/index.ts
+++ b/frontend/src/app/spaces/types/index.ts
@@ -1,0 +1,7 @@
+// Re-export all types for easier imports
+// Knowledge Microservice types
+export * as Spaces from './spaces'      // spaces DB
+export * as Content from './content'     // content_sources DB
+
+// Canvas Microservice types  
+export * as Canvas from './canvas'      // Canvas service (separate microservice)

--- a/frontend/src/app/spaces/types/shared.ts
+++ b/frontend/src/app/spaces/types/shared.ts
@@ -1,0 +1,163 @@
+// Shared types, enums, and interfaces used across the spaces domain
+// (spaces, content, canvas) to avoid duplication and maintain consistency.
+
+// =========================================================================
+// ENUMS
+// =========================================================================
+
+export enum ContentSourceType {
+  FILE = 'file',
+  URL = 'url', 
+  TEXT = 'text',
+  GOOGLE_DRIVE = 'google_drive'
+}
+
+export enum ContentSourceStatus {
+  PENDING = 'pending',
+  PROCESSING = 'processing', 
+  COMPLETED = 'completed',
+  FAILED = 'failed'
+}
+
+export enum ProcessingStage {
+  UPLOAD = 'upload',
+  EXTRACTION = 'extraction',
+  ANALYSIS = 'analysis', 
+  INDEXING = 'indexing',
+  COMPLETE = 'complete'
+}
+
+export enum AccessLevel {
+  PRIVATE = 'private',
+  SHARED = 'shared',
+  PUBLIC = 'public'
+}
+
+// =========================================================================
+// BASE INTERFACES
+// =========================================================================
+
+export interface BaseEntity {
+  id: string
+  createdAt: Date | string
+  updatedAt: Date | string
+}
+
+export interface BaseEntityWithUser extends BaseEntity {
+  userId: string
+}
+
+export interface Timestamps {
+  createdAt: Date | string
+  updatedAt: Date | string
+}
+
+// =========================================================================
+// ERROR HANDLING
+// =========================================================================
+
+export interface ErrorState {
+  type: 'validation' | 'network' | 'server' | 'processing' | 'authentication' | 'permission'
+  message: string
+  code: string
+  retryable: boolean
+  actions?: ErrorAction[]
+  details?: Record<string, any>
+}
+
+export interface ErrorAction {
+  label: string
+  action: () => void | Promise<void>
+  variant: 'primary' | 'secondary' | 'destructive'
+  loading?: boolean
+}
+
+export interface ValidationError {
+  field: string
+  message: string
+  code: string
+}
+
+export interface FormErrors {
+  [field: string]: ValidationError[]
+}
+
+export interface ApiError {
+  code: string
+  message: string
+  details?: Record<string, any>
+  timestamp: string
+  requestId?: string
+}
+
+// =========================================================================
+// API RESPONSE TYPES
+// =========================================================================
+
+export interface ActionResult<T> {
+  ok: boolean
+  data?: T
+  error?: {
+    code: string
+    message: string
+    details?: Record<string, any>
+  }
+}
+
+export interface ServerActionResult<T> extends ActionResult<T> {
+  timestamp: string
+  requestId?: string
+}
+
+// =========================================================================
+// UTILITY TYPES
+// =========================================================================
+
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P]
+}
+
+export type RequiredFields<T, K extends keyof T> = T & Required<Pick<T, K>>
+
+export type OptionalFields<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
+
+// =========================================================================
+// COMMON UI STATE
+// =========================================================================
+
+export interface LoadingStates {
+  [key: string]: boolean
+}
+
+export interface FilterState {
+  searchTerm: string
+  sortBy?: string
+  sortOrder?: 'asc' | 'desc'
+  page: number
+  pageSize: number
+}
+
+// =========================================================================
+// METADATA
+// =========================================================================
+
+export interface ContentMetadata {
+  mimeType: string
+  sizeBytes: number
+  filename?: string
+  title?: string
+  extractedText?: string
+  thumbnailUrl?: string
+  contentSummary?: string
+  detectedLanguage?: string
+  wordCount?: number
+  pageCount?: number
+}
+
+export interface ProcessingMetadata {
+  processingStartedAt?: Date | string
+  processingCompletedAt?: Date | string
+  processingError?: string
+  stage: ProcessingStage
+  progress: number
+}

--- a/frontend/src/app/spaces/types/spaces.ts
+++ b/frontend/src/app/spaces/types/spaces.ts
@@ -19,8 +19,8 @@ export interface Space {
   userCount?: number
 
   // Enhanced fields for new functionality
-  collaboration_settings?: CollaborationSettings
-  processing_stats?: ProcessingStats
+  collaborationSettings?: CollaborationSettings
+  processingStats?: ProcessingStats
 }
 
 // Collaboration settings for spaces

--- a/frontend/src/app/spaces/types/spaces.ts
+++ b/frontend/src/app/spaces/types/spaces.ts
@@ -1,4 +1,6 @@
-// Space-related types derived from knowledge.proto
+// Spaces types for the Knowledge Microservice (spaces DB)
+// This handles space management, collaboration, and metadata
+// Related types: ./content.ts (content_sources DB), ./canvas.ts (Canvas microservice)
 
 export interface Space {
   id: string
@@ -15,33 +17,81 @@ export interface Space {
   last_updated_at: Date | string
   contentCount?: number
   userCount?: number
+
+  // Enhanced fields for new functionality
+  collaboration_settings?: CollaborationSettings
+  processing_stats?: ProcessingStats
 }
 
-export interface ContentSource {
-  id: string
-  spaceId: string
-  name: string
-  type: ContentSourceType
-  url?: string
-  size?: number
-  mimeType?: string
-  status: ContentSourceStatus
-  createdAt: string
-  updatedAt: string
+// Collaboration settings for spaces
+export interface CollaborationSettings {
+  allowComments: boolean
+  allowEditing: boolean
+  shareSettings: {
+    publicLink?: string
+    expiresAt?: Date
+    permissions: 'view' | 'comment' | 'edit'
+  }
+  invitedUsers: CollaborationUser[]
 }
 
-export enum ContentSourceType {
-  UNKNOWN = 'UNKNOWN',
-  URL = 'URL',
-  FILE = 'FILE',
-  TEXT = 'TEXT'
+export interface CollaborationUser {
+  userId: string
+  email: string
+  role: 'viewer' | 'editor' | 'admin'
+  invitedAt: Date
+  lastActive?: Date
 }
 
-export enum ContentSourceStatus {
-  PENDING = 'PENDING',
-  PROCESSING = 'PROCESSING',
-  COMPLETED = 'COMPLETED',
-  FAILED = 'FAILED'
+// Processing statistics for spaces
+export interface ProcessingStats {
+  totalDocuments: number
+  processedDocuments: number
+  failedDocuments: number
+  totalProcessingTime: number
+  lastProcessedAt?: Date
+  averageProcessingTime: number
+}
+
+
+
+// Error handling types
+export interface ErrorState {
+  type: 'validation' | 'network' | 'server' | 'processing' | 'authentication' | 'permission'
+  message: string
+  code: string
+  retryable: boolean
+  actions?: ErrorAction[]
+  details?: Record<string, any>
+}
+
+export interface ErrorAction {
+  label: string
+  action: () => void | Promise<void>
+  variant: 'primary' | 'secondary' | 'destructive'
+  loading?: boolean
+}
+
+
+
+// Validation error types
+export interface ValidationError {
+  field: string
+  message: string
+  code: string
+}
+
+export interface FormErrors {
+  [field: string]: ValidationError[]
+}
+
+// API error response type
+export interface ApiError {
+  code: string
+  message: string
+  details?: Record<string, any>
+  timestamp: string
+  requestId?: string
 }
 
 export interface SpaceFilters {
@@ -122,6 +172,65 @@ export interface SpacesUIState {
   selectedSpaceId: string | null
 }
 
+// Enhanced state management for spaces and content
+// Note: Content-related types are imported from ./content.ts
+export interface EnhancedSpacesState extends SpacesUIState {
+  // Content management (types from content.ts)
+  contentSources: Record<string, any[]>  // spaceId -> content sources
+  uploadProgress: Record<string, any>   // fileId -> progress  
+  processingStatus: Record<string, any> // contentId -> status
+
+  // Upload sessions (types from content.ts)
+  activeSessions: Record<string, any>    // sessionId -> session
+
+  // Error states
+  errors: Record<string, ErrorState>              // errorId -> error
+
+  // Loading states
+  loadingStates: {
+    spaces: boolean
+    contentSources: Record<string, boolean>       // spaceId -> loading
+    uploads: Record<string, boolean>              // sessionId -> loading
+  }
+}
+
+
+
+// Space detail page UI state
+export interface SpaceDetailState {
+  spaceId: string
+  activeSection: 'canvas' | 'documents' | 'chat'
+  canvasZoom: number
+  canvasCenter: { x: number; y: number }
+  selectedNodes: string[]
+  sidebarCollapsed: boolean
+  documentsPanelCollapsed: boolean
+}
+
+// Grid size options for gallery view
+export type GridSize = 'small' | 'medium' | 'large'
+
+// Sort options for different views
+export type SortOption = {
+  key: string
+  label: string
+  direction: 'asc' | 'desc'
+}
+
+// Filter options
+export interface FilterOptions {
+  accessLevels: ('private' | 'shared' | 'public')[]
+  dateRange?: {
+    start: Date
+    end: Date
+  }
+  sizeRange?: {
+    min: number
+    max: number
+  }
+  hasDocuments?: boolean
+}
+
 // Server Action Result Types
 export interface ActionResult<T> {
   ok: boolean
@@ -129,8 +238,17 @@ export interface ActionResult<T> {
   error?: {
     code: string
     message: string
+    details?: Record<string, any>
   }
 }
+
+// Enhanced server action types
+export interface ServerActionResult<T> extends ActionResult<T> {
+  timestamp: string
+  requestId?: string
+}
+
+
 
 export interface SpaceCardProps {
   space: SpaceWithStats
@@ -140,3 +258,28 @@ export interface SpaceCardProps {
   onDelete: (spaceId: string) => void
   isDeleting?: boolean
 }
+
+// Space-specific component prop types
+export interface SpaceHeaderProps {
+  space: Space
+  onEdit: () => void
+  onDelete: () => void
+  onShare: () => void
+  isEditing?: boolean
+}
+
+// Utility types
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P]
+}
+
+export type RequiredFields<T, K extends keyof T> = T & Required<Pick<T, K>>
+
+export type OptionalFields<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
+
+// Constants for UI
+export const GRID_SIZES = {
+  small: { columns: 4, cardHeight: 200 },
+  medium: { columns: 3, cardHeight: 250 },
+  large: { columns: 2, cardHeight: 300 }
+} as const

--- a/frontend/src/app/spaces/types/spaces.ts
+++ b/frontend/src/app/spaces/types/spaces.ts
@@ -1,29 +1,39 @@
-// Spaces types for the Knowledge Microservice (spaces DB)
-// This handles space management, collaboration, and metadata
-// Related types: ./content.ts (content_sources DB), ./canvas.ts (Canvas microservice)
+import type { 
+  BaseEntityWithUser, 
+  AccessLevel, 
+  ErrorState, 
+  ErrorAction, 
+  ValidationError, 
+  FormErrors, 
+  ApiError, 
+  ActionResult, 
+  ServerActionResult,
+  DeepPartial,
+  RequiredFields,
+  OptionalFields,
+  FilterState
+} from './shared'
 
-export interface Space {
-  id: string
-  userId: string
+// =========================================================================
+// SPACE INTERFACES
+// =========================================================================
+
+export interface Space extends BaseEntityWithUser {
   title: string
   description: string
   icon?: string
   coverImage?: string
   keywords: string[]
-  accessLevel: 'private' | 'shared' | 'public'
+  accessLevel: AccessLevel
   documentCount: number
   totalSizeBytes: number
-  createdAt: Date | string
   lastUpdatedAt: Date | string
   contentCount?: number
   userCount?: number
-
-  // Enhanced fields for new functionality
   collaborationSettings?: CollaborationSettings
   processingStats?: ProcessingStats
 }
 
-// Collaboration settings for spaces
 export interface CollaborationSettings {
   allowComments: boolean
   allowEditing: boolean
@@ -43,7 +53,6 @@ export interface CollaborationUser {
   lastActive?: Date
 }
 
-// Processing statistics for spaces
 export interface ProcessingStats {
   totalDocuments: number
   processedDocuments: number
@@ -53,54 +62,14 @@ export interface ProcessingStats {
   averageProcessingTime: number
 }
 
+// =========================================================================
+// SPACE OPERATIONS
+// =========================================================================
 
-
-// Error handling types
-export interface ErrorState {
-  type: 'validation' | 'network' | 'server' | 'processing' | 'authentication' | 'permission'
-  message: string
-  code: string
-  retryable: boolean
-  actions?: ErrorAction[]
-  details?: Record<string, any>
-}
-
-export interface ErrorAction {
-  label: string
-  action: () => void | Promise<void>
-  variant: 'primary' | 'secondary' | 'destructive'
-  loading?: boolean
-}
-
-
-
-// Validation error types
-export interface ValidationError {
-  field: string
-  message: string
-  code: string
-}
-
-export interface FormErrors {
-  [field: string]: ValidationError[]
-}
-
-// API error response type
-export interface ApiError {
-  code: string
-  message: string
-  details?: Record<string, any>
-  timestamp: string
-  requestId?: string
-}
-
-export interface SpaceFilters {
-  q?: string              // Search query
-  keywords?: string[]     // Filter by keywords
+export interface SpaceFilters extends FilterState {
+  q?: string
+  keywords?: string[]
   sortBy?: 'name' | 'created' | 'updated' | 'documents'
-  sortOrder?: 'asc' | 'desc'
-  page?: number
-  pageSize?: number
 }
 
 export interface SpaceWithStats extends Space {
@@ -138,6 +107,10 @@ export interface CreateUploadURLResponse {
   expiresAt: string
 }
 
+// =========================================================================
+// SEARCH & PAGINATION
+// =========================================================================
+
 export interface SearchSpacesRequest {
   q?: string
   keywords?: string[]
@@ -155,8 +128,12 @@ export interface SearchSpacesResponse {
   pageSize: number
 }
 
-// UI-specific types
+// =========================================================================
+// UI STATE MANAGEMENT
+// =========================================================================
+
 export type ViewMode = 'gallery' | 'list' | 'canvas'
+export type GridSize = 'small' | 'medium' | 'large'
 
 export interface SpacesUIState {
   view: ViewMode
@@ -167,36 +144,24 @@ export interface SpacesUIState {
   page: number
   pageSize: number
   isCreating: boolean
-  isDeleting: string | null // spaceId being deleted
+  isDeleting: string | null
   lastError: string | null
   selectedSpaceId: string | null
 }
 
-// Enhanced state management for spaces and content
-// Note: Content-related types are imported from ./content.ts
 export interface EnhancedSpacesState extends SpacesUIState {
-  // Content management (types from content.ts)
-  contentSources: Record<string, any[]>  // spaceId -> content sources
-  uploadProgress: Record<string, any>   // fileId -> progress  
-  processingStatus: Record<string, any> // contentId -> status
-
-  // Upload sessions (types from content.ts)
-  activeSessions: Record<string, any>    // sessionId -> session
-
-  // Error states
-  errors: Record<string, ErrorState>              // errorId -> error
-
-  // Loading states
+  contentSources: Record<string, any[]>
+  uploadProgress: Record<string, any>
+  processingStatus: Record<string, any>
+  activeSessions: Record<string, any>
+  errors: Record<string, ErrorState>
   loadingStates: {
     spaces: boolean
-    contentSources: Record<string, boolean>       // spaceId -> loading
-    uploads: Record<string, boolean>              // sessionId -> loading
+    contentSources: Record<string, boolean>
+    uploads: Record<string, boolean>
   }
 }
 
-
-
-// Space detail page UI state
 export interface SpaceDetailState {
   spaceId: string
   activeSection: 'canvas' | 'documents' | 'chat'
@@ -207,19 +172,39 @@ export interface SpaceDetailState {
   documentsPanelCollapsed: boolean
 }
 
-// Grid size options for gallery view
-export type GridSize = 'small' | 'medium' | 'large'
+// =========================================================================
+// COMPONENT PROPS
+// =========================================================================
 
-// Sort options for different views
+export interface SpaceCardProps {
+  space: SpaceWithStats
+  view: ViewMode
+  onSelect: (spaceId: string) => void
+  onEdit: (spaceId: string) => void
+  onDelete: (spaceId: string) => void
+  isDeleting?: boolean
+}
+
+export interface SpaceHeaderProps {
+  space: Space
+  onEdit: () => void
+  onDelete: () => void
+  onShare: () => void
+  isEditing?: boolean
+}
+
+// =========================================================================
+// FILTERING & SORTING
+// =========================================================================
+
 export type SortOption = {
   key: string
   label: string
   direction: 'asc' | 'desc'
 }
 
-// Filter options
 export interface FilterOptions {
-  accessLevels: ('private' | 'shared' | 'public')[]
+  accessLevels: AccessLevel[]
   dateRange?: {
     start: Date
     end: Date
@@ -231,55 +216,41 @@ export interface FilterOptions {
   hasDocuments?: boolean
 }
 
-// Server Action Result Types
-export interface ActionResult<T> {
-  ok: boolean
-  data?: T
-  error?: {
-    code: string
-    message: string
-    details?: Record<string, any>
-  }
-}
+// =========================================================================
+// CONSTANTS
+// =========================================================================
 
-// Enhanced server action types
-export interface ServerActionResult<T> extends ActionResult<T> {
-  timestamp: string
-  requestId?: string
-}
-
-
-
-export interface SpaceCardProps {
-  space: SpaceWithStats
-  view: ViewMode
-  onSelect: (spaceId: string) => void
-  onEdit: (spaceId: string) => void
-  onDelete: (spaceId: string) => void
-  isDeleting?: boolean
-}
-
-// Space-specific component prop types
-export interface SpaceHeaderProps {
-  space: Space
-  onEdit: () => void
-  onDelete: () => void
-  onShare: () => void
-  isEditing?: boolean
-}
-
-// Utility types
-export type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P]
-}
-
-export type RequiredFields<T, K extends keyof T> = T & Required<Pick<T, K>>
-
-export type OptionalFields<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
-
-// Constants for UI
 export const GRID_SIZES = {
   small: { columns: 4, cardHeight: 200 },
   medium: { columns: 3, cardHeight: 250 },
   large: { columns: 2, cardHeight: 300 }
 } as const
+
+export const SORT_OPTIONS: SortOption[] = [
+  { key: 'lastUpdatedAt', label: 'Last Updated', direction: 'desc' },
+  { key: 'createdAt', label: 'Date Created', direction: 'desc' },
+  { key: 'title', label: 'Title', direction: 'asc' },
+  { key: 'documentCount', label: 'Documents', direction: 'desc' }
+] as const
+
+export const DEFAULT_PAGE_SIZE = 12
+export const MAX_KEYWORDS = 10
+export const MAX_DESCRIPTION_LENGTH = 500
+export const MAX_TITLE_LENGTH = 100
+
+// =========================================================================
+// RE-EXPORT SHARED TYPES
+// =========================================================================
+
+export type { 
+  ErrorState, 
+  ErrorAction, 
+  ValidationError, 
+  FormErrors, 
+  ApiError, 
+  ActionResult, 
+  ServerActionResult,
+  DeepPartial,
+  RequiredFields,
+  OptionalFields
+}

--- a/frontend/src/app/spaces/types/spaces.ts
+++ b/frontend/src/app/spaces/types/spaces.ts
@@ -8,13 +8,13 @@ export interface Space {
   title: string
   description: string
   icon?: string
-  cover_image?: string
+  coverImage?: string
   keywords: string[]
-  access_level: 'private' | 'shared' | 'public'
-  document_count: number
-  total_size_bytes: number
-  created_at: Date | string
-  last_updated_at: Date | string
+  accessLevel: 'private' | 'shared' | 'public'
+  documentCount: number
+  totalSizeBytes: number
+  createdAt: Date | string
+  lastUpdatedAt: Date | string
   contentCount?: number
   userCount?: number
 


### PR DESCRIPTION
## Summary
- Updates the spaces frontend with enhanced views and infrastructure.  
- Latest edits confirm: table header/column alignment fixed in `ListView`, tooltips removed by no-op components, and `Toaster` wiring added to `RootLayout`.

## Key changes
- **SpaceCard**
  - Cover images with gradient overlay and hover scale
  - Access level badges with proper colors/icons
  - Hover-triggered edit button (opacity transitions)
  - Enhanced metadata: created date, document count, last updated
  - Tooltip content removed from UI (kept API as no-op to avoid breakage)
  - Keywords overflow handling and responsive layout

- **GalleryView**
  - Grid size controls: small/medium/large with icons
  - Dynamic grid classes by selected size with responsive breakpoints
  - Improved empty state and header with space count
  - Loading skeleton mirroring grid layout

- **ListView**
  - Single table with sticky header to align columns and rows
  - Sortable columns with visual indicators
  - Inline editing (title, keywords, description)
  - Hover states, access level badges, centered document count with modal preview
  - Consistent date formatting and improved empty state

- **CanvasView**
  - Carousel navigation (prev/next)
  - 3D depth side cards and animated gradient background
  - Mini‑map with clickable dots and quick preview modal
  - Center card with metadata display and navigation controls

- **UI components**
  - `Badge`, `Table`, `Dialog` added; `Tooltip` exported as no‑op
  - `Toaster` mounted in `RootLayout` and `use-toast` import corrected

- **Types and data shaping**
  - `Space` extended: `cover_image`, `access_level`, `document_count`, `total_size_bytes`, `created_at`, `last_updated_at`
  - Safer date handling and icon mapping

- **Requirements mapping**
  - 1.1–1.4, 5.1–5.3 satisfied across updated components (styling, responsiveness, interactions) at `.kiro/specs/spaces-page-enhancement/tasks.md`

Files changed (high level)
- Added: `frontend/src/app/spaces/types/canvas.ts`, `frontend/src/app/spaces/types/content.ts`, `frontend/src/app/spaces/types/index.ts`  
- Modified: `frontend/src/app/spaces/types/spaces.ts`  
(Also front-end component edits referenced above across `SpaceCard`, `GalleryView`, `ListView`, `CanvasView`, and UI components.)

Reviewer notes
- Verify existing imports now that types are re-exported via `frontend/src/app/spaces/types/index.ts`.
- Confirm `Date | string` fields are handled consistently at runtime (prefer parsing ISO strings where needed).
- Check that `Tooltip` no-op preserves runtime imports to avoid breaking third-party consumers.
- Run full frontend typecheck/build and smoke test space list/detail, upload flows, and gallery/list interactions.

Suggested checklist
- [ ] Run `npm run build` / typecheck and fix broken imports
- [ ] Smoke test spaces pages (list, gallery, detail, upload flows)
- [ ] Confirm `Toaster` behavior in `RootLayout`
- [ ] Update `.kiro/specs/spaces-page-enhancement/tasks.md` if additional items are completed

Summary of this output
- Generated a PR description in the requested `## Summary` / `## Key changes` format covering UI, types, and infra updates for the Spaces page.