### PR TITLE
feat: Implement RCP for Content Source Deletion

### DIFF
--- a/docs/coding-guide/BACKEND.md
+++ b/docs/coding-guide/BACKEND.md
@@ -218,18 +218,26 @@ Many services need to upload and download large files or binary blobs. We use an
 
 ### **Protocol Buffers**
 
-# Generate Go gRPC code  
-protoc --go_out=. --go_opt=paths=source_relative \
-       --go-grpc_out=. --go-grpc_opt=paths=source_relative \
-       api/proto/v1/*.proto
+# Install protoc Go plugins (run once per dev machine)
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+export PATH="$(go env GOPATH)/bin:$PATH"
+
+# Generate Go gRPC code from the service directory (e.g., ms_knowledge/)
+# This writes .pb.go files to the SAME directory as the .proto files
+protoc -I . \
+  --go_out=. --go_opt=paths=source_relative \
+  --go-grpc_out=. --go-grpc_opt=paths=source_relative \
+  api/proto/v1/*.proto
 
 # Generate Python gRPC code  
 python -m grpc_tools.protoc -I./api/proto/v1 --python_out=. --grpc_python_out=. api/proto/v1/*.proto
 
-# Generate gRPC-web client code for frontend  
-protoc -I./api/proto/v1 --js_out=import_style=commonjs:frontend/src/api/generated/ \
-       --grpc-web_out=import_style=commonjs,mode=grpcwebtext:frontend/src/api/generated/ \
-       api/proto/v1/*.proto
+# Generate gRPC-web client code for frontend
+protoc -I . \
+  --js_out=import_style=commonjs:frontend/src/api/generated/ \
+  --grpc-web_out=import_style=commonjs,mode=grpcwebtext:frontend/src/api/generated/ \
+  api/proto/v1/*.proto
 
 ### **Ent (Go)**
 

--- a/ms_knowledge/api/proto/v1/knowledge.pb.go
+++ b/ms_knowledge/api/proto/v1/knowledge.pb.go
@@ -1596,6 +1596,50 @@ func (x *UpdateContentSourceStatusRequest) GetErrorMessage() string {
 	return ""
 }
 
+type DeleteContentSourceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteContentSourceRequest) Reset() {
+	*x = DeleteContentSourceRequest{}
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteContentSourceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteContentSourceRequest) ProtoMessage() {}
+
+func (x *DeleteContentSourceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteContentSourceRequest.ProtoReflect.Descriptor instead.
+func (*DeleteContentSourceRequest) Descriptor() ([]byte, []int) {
+	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *DeleteContentSourceRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
 // Download URL generation
 type GenerateDownloadURLRequest struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
@@ -1607,7 +1651,7 @@ type GenerateDownloadURLRequest struct {
 
 func (x *GenerateDownloadURLRequest) Reset() {
 	*x = GenerateDownloadURLRequest{}
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[20]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1619,7 +1663,7 @@ func (x *GenerateDownloadURLRequest) String() string {
 func (*GenerateDownloadURLRequest) ProtoMessage() {}
 
 func (x *GenerateDownloadURLRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[20]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1632,7 +1676,7 @@ func (x *GenerateDownloadURLRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateDownloadURLRequest.ProtoReflect.Descriptor instead.
 func (*GenerateDownloadURLRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{20}
+	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GenerateDownloadURLRequest) GetContentSourceId() string {
@@ -1660,7 +1704,7 @@ type GenerateDownloadURLResponse struct {
 
 func (x *GenerateDownloadURLResponse) Reset() {
 	*x = GenerateDownloadURLResponse{}
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[21]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1672,7 +1716,7 @@ func (x *GenerateDownloadURLResponse) String() string {
 func (*GenerateDownloadURLResponse) ProtoMessage() {}
 
 func (x *GenerateDownloadURLResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[21]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1685,7 +1729,7 @@ func (x *GenerateDownloadURLResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateDownloadURLResponse.ProtoReflect.Descriptor instead.
 func (*GenerateDownloadURLResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{21}
+	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GenerateDownloadURLResponse) GetUrl() string {
@@ -1722,7 +1766,7 @@ type CreateKnowledgeLinkRequest struct {
 
 func (x *CreateKnowledgeLinkRequest) Reset() {
 	*x = CreateKnowledgeLinkRequest{}
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[22]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1734,7 +1778,7 @@ func (x *CreateKnowledgeLinkRequest) String() string {
 func (*CreateKnowledgeLinkRequest) ProtoMessage() {}
 
 func (x *CreateKnowledgeLinkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[22]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1747,7 +1791,7 @@ func (x *CreateKnowledgeLinkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateKnowledgeLinkRequest.ProtoReflect.Descriptor instead.
 func (*CreateKnowledgeLinkRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{22}
+	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *CreateKnowledgeLinkRequest) GetFromContentId() string {
@@ -1787,7 +1831,7 @@ type GetKnowledgeLinkRequest struct {
 
 func (x *GetKnowledgeLinkRequest) Reset() {
 	*x = GetKnowledgeLinkRequest{}
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[23]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1799,7 +1843,7 @@ func (x *GetKnowledgeLinkRequest) String() string {
 func (*GetKnowledgeLinkRequest) ProtoMessage() {}
 
 func (x *GetKnowledgeLinkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[23]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1812,7 +1856,7 @@ func (x *GetKnowledgeLinkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetKnowledgeLinkRequest.ProtoReflect.Descriptor instead.
 func (*GetKnowledgeLinkRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{23}
+	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetKnowledgeLinkRequest) GetId() string {
@@ -1835,7 +1879,7 @@ type ListKnowledgeLinksRequest struct {
 
 func (x *ListKnowledgeLinksRequest) Reset() {
 	*x = ListKnowledgeLinksRequest{}
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[24]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1847,7 +1891,7 @@ func (x *ListKnowledgeLinksRequest) String() string {
 func (*ListKnowledgeLinksRequest) ProtoMessage() {}
 
 func (x *ListKnowledgeLinksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[24]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1860,7 +1904,7 @@ func (x *ListKnowledgeLinksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListKnowledgeLinksRequest.ProtoReflect.Descriptor instead.
 func (*ListKnowledgeLinksRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{24}
+	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ListKnowledgeLinksRequest) GetContentId() string {
@@ -1901,7 +1945,7 @@ type ListKnowledgeLinksResponse struct {
 
 func (x *ListKnowledgeLinksResponse) Reset() {
 	*x = ListKnowledgeLinksResponse{}
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[25]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1913,7 +1957,7 @@ func (x *ListKnowledgeLinksResponse) String() string {
 func (*ListKnowledgeLinksResponse) ProtoMessage() {}
 
 func (x *ListKnowledgeLinksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[25]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1926,7 +1970,7 @@ func (x *ListKnowledgeLinksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListKnowledgeLinksResponse.ProtoReflect.Descriptor instead.
 func (*ListKnowledgeLinksResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{25}
+	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ListKnowledgeLinksResponse) GetItems() []*EnrichedKnowledgeLink {
@@ -1955,7 +1999,7 @@ type ListAllSpaceLinksRequest struct {
 
 func (x *ListAllSpaceLinksRequest) Reset() {
 	*x = ListAllSpaceLinksRequest{}
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[26]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1967,7 +2011,7 @@ func (x *ListAllSpaceLinksRequest) String() string {
 func (*ListAllSpaceLinksRequest) ProtoMessage() {}
 
 func (x *ListAllSpaceLinksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[26]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1980,7 +2024,7 @@ func (x *ListAllSpaceLinksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAllSpaceLinksRequest.ProtoReflect.Descriptor instead.
 func (*ListAllSpaceLinksRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{26}
+	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ListAllSpaceLinksRequest) GetSpaceId() string {
@@ -2014,7 +2058,7 @@ type ListAllSpaceLinksResponse struct {
 
 func (x *ListAllSpaceLinksResponse) Reset() {
 	*x = ListAllSpaceLinksResponse{}
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[27]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2026,7 +2070,7 @@ func (x *ListAllSpaceLinksResponse) String() string {
 func (*ListAllSpaceLinksResponse) ProtoMessage() {}
 
 func (x *ListAllSpaceLinksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[27]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2039,7 +2083,7 @@ func (x *ListAllSpaceLinksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAllSpaceLinksResponse.ProtoReflect.Descriptor instead.
 func (*ListAllSpaceLinksResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{27}
+	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ListAllSpaceLinksResponse) GetItems() []*KnowledgeLink {
@@ -2067,7 +2111,7 @@ type UpdateKnowledgeLinkRequest struct {
 
 func (x *UpdateKnowledgeLinkRequest) Reset() {
 	*x = UpdateKnowledgeLinkRequest{}
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[28]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2079,7 +2123,7 @@ func (x *UpdateKnowledgeLinkRequest) String() string {
 func (*UpdateKnowledgeLinkRequest) ProtoMessage() {}
 
 func (x *UpdateKnowledgeLinkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[28]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2092,7 +2136,7 @@ func (x *UpdateKnowledgeLinkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateKnowledgeLinkRequest.ProtoReflect.Descriptor instead.
 func (*UpdateKnowledgeLinkRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{28}
+	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *UpdateKnowledgeLinkRequest) GetId() string {
@@ -2125,7 +2169,7 @@ type DeleteKnowledgeLinkRequest struct {
 
 func (x *DeleteKnowledgeLinkRequest) Reset() {
 	*x = DeleteKnowledgeLinkRequest{}
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[29]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2137,7 +2181,7 @@ func (x *DeleteKnowledgeLinkRequest) String() string {
 func (*DeleteKnowledgeLinkRequest) ProtoMessage() {}
 
 func (x *DeleteKnowledgeLinkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[29]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2150,7 +2194,7 @@ func (x *DeleteKnowledgeLinkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteKnowledgeLinkRequest.ProtoReflect.Descriptor instead.
 func (*DeleteKnowledgeLinkRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{29}
+	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *DeleteKnowledgeLinkRequest) GetId() string {
@@ -2170,7 +2214,7 @@ type GetBacklinksRequest struct {
 
 func (x *GetBacklinksRequest) Reset() {
 	*x = GetBacklinksRequest{}
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[30]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2182,7 +2226,7 @@ func (x *GetBacklinksRequest) String() string {
 func (*GetBacklinksRequest) ProtoMessage() {}
 
 func (x *GetBacklinksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[30]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2195,7 +2239,7 @@ func (x *GetBacklinksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBacklinksRequest.ProtoReflect.Descriptor instead.
 func (*GetBacklinksRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{30}
+	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetBacklinksRequest) GetContentId() string {
@@ -2222,7 +2266,7 @@ type GetBacklinksResponse struct {
 
 func (x *GetBacklinksResponse) Reset() {
 	*x = GetBacklinksResponse{}
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[31]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2234,7 +2278,7 @@ func (x *GetBacklinksResponse) String() string {
 func (*GetBacklinksResponse) ProtoMessage() {}
 
 func (x *GetBacklinksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[31]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2247,7 +2291,7 @@ func (x *GetBacklinksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBacklinksResponse.ProtoReflect.Descriptor instead.
 func (*GetBacklinksResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{31}
+	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetBacklinksResponse) GetItems() []*KnowledgeLink {
@@ -2275,7 +2319,7 @@ type HealthStatus struct {
 
 func (x *HealthStatus) Reset() {
 	*x = HealthStatus{}
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[32]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2287,7 +2331,7 @@ func (x *HealthStatus) String() string {
 func (*HealthStatus) ProtoMessage() {}
 
 func (x *HealthStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_v1_knowledge_proto_msgTypes[32]
+	mi := &file_api_proto_v1_knowledge_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2300,7 +2344,7 @@ func (x *HealthStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthStatus.ProtoReflect.Descriptor instead.
 func (*HealthStatus) Descriptor() ([]byte, []int) {
-	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{32}
+	return file_api_proto_v1_knowledge_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *HealthStatus) GetStatus() string {
@@ -2450,7 +2494,9 @@ const file_api_proto_v1_knowledge_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x123\n" +
 	"\x06status\x18\x02 \x01(\x0e2\x1b.knowledge.v1.ContentStatusR\x06status\x12.\n" +
 	"\x13processed_blob_hash\x18\x03 \x01(\tR\x11processedBlobHash\x12#\n" +
-	"\rerror_message\x18\x04 \x01(\tR\ferrorMessage\"q\n" +
+	"\rerror_message\x18\x04 \x01(\tR\ferrorMessage\",\n" +
+	"\x1aDeleteContentSourceRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"q\n" +
 	"\x1aGenerateDownloadURLRequest\x12*\n" +
 	"\x11content_source_id\x18\x01 \x01(\tR\x0fcontentSourceId\x12'\n" +
 	"\x0fexpires_seconds\x18\x02 \x01(\x05R\x0eexpiresSeconds\"\x89\x01\n" +
@@ -2528,7 +2574,7 @@ const file_api_proto_v1_knowledge_proto_rawDesc = "" +
 	"\x1aLINK_DIRECTION_UNSPECIFIED\x10\x00\x12\v\n" +
 	"\aINBOUND\x10\x01\x12\f\n" +
 	"\bOUTBOUND\x10\x02\x12\b\n" +
-	"\x04BOTH\x10\x032\x9b\r\n" +
+	"\x04BOTH\x10\x032\xf4\r\n" +
 	"\x10KnowledgeService\x12D\n" +
 	"\vCreateSpace\x12 .knowledge.v1.CreateSpaceRequest\x1a\x13.knowledge.v1.Space\x12>\n" +
 	"\bGetSpace\x12\x1d.knowledge.v1.GetSpaceRequest\x1a\x13.knowledge.v1.Space\x12O\n" +
@@ -2540,7 +2586,8 @@ const file_api_proto_v1_knowledge_proto_rawDesc = "" +
 	"\rConfirmUpload\x12\".knowledge.v1.ConfirmUploadRequest\x1a\x1b.knowledge.v1.ContentSource\x12V\n" +
 	"\x10GetContentSource\x12%.knowledge.v1.GetContentSourceRequest\x1a\x1b.knowledge.v1.ContentSource\x12g\n" +
 	"\x12ListContentSources\x12'.knowledge.v1.ListContentSourcesRequest\x1a(.knowledge.v1.ListContentSourcesResponse\x12h\n" +
-	"\x19UpdateContentSourceStatus\x12..knowledge.v1.UpdateContentSourceStatusRequest\x1a\x1b.knowledge.v1.ContentSource\x12j\n" +
+	"\x19UpdateContentSourceStatus\x12..knowledge.v1.UpdateContentSourceStatusRequest\x1a\x1b.knowledge.v1.ContentSource\x12W\n" +
+	"\x13DeleteContentSource\x12(.knowledge.v1.DeleteContentSourceRequest\x1a\x16.google.protobuf.Empty\x12j\n" +
 	"\x13GenerateDownloadURL\x12(.knowledge.v1.GenerateDownloadURLRequest\x1a).knowledge.v1.GenerateDownloadURLResponse\x12\\\n" +
 	"\x13CreateKnowledgeLink\x12(.knowledge.v1.CreateKnowledgeLinkRequest\x1a\x1b.knowledge.v1.KnowledgeLink\x12^\n" +
 	"\x10GetKnowledgeLink\x12%.knowledge.v1.GetKnowledgeLinkRequest\x1a#.knowledge.v1.EnrichedKnowledgeLink\x12g\n" +
@@ -2564,7 +2611,7 @@ func file_api_proto_v1_knowledge_proto_rawDescGZIP() []byte {
 }
 
 var file_api_proto_v1_knowledge_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_api_proto_v1_knowledge_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_api_proto_v1_knowledge_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_api_proto_v1_knowledge_proto_goTypes = []any{
 	(ContentStatus)(0),                       // 0: knowledge.v1.ContentStatus
 	(RelationType)(0),                        // 1: knowledge.v1.RelationType
@@ -2589,55 +2636,56 @@ var file_api_proto_v1_knowledge_proto_goTypes = []any{
 	(*ListContentSourcesRequest)(nil),        // 20: knowledge.v1.ListContentSourcesRequest
 	(*ListContentSourcesResponse)(nil),       // 21: knowledge.v1.ListContentSourcesResponse
 	(*UpdateContentSourceStatusRequest)(nil), // 22: knowledge.v1.UpdateContentSourceStatusRequest
-	(*GenerateDownloadURLRequest)(nil),       // 23: knowledge.v1.GenerateDownloadURLRequest
-	(*GenerateDownloadURLResponse)(nil),      // 24: knowledge.v1.GenerateDownloadURLResponse
-	(*CreateKnowledgeLinkRequest)(nil),       // 25: knowledge.v1.CreateKnowledgeLinkRequest
-	(*GetKnowledgeLinkRequest)(nil),          // 26: knowledge.v1.GetKnowledgeLinkRequest
-	(*ListKnowledgeLinksRequest)(nil),        // 27: knowledge.v1.ListKnowledgeLinksRequest
-	(*ListKnowledgeLinksResponse)(nil),       // 28: knowledge.v1.ListKnowledgeLinksResponse
-	(*ListAllSpaceLinksRequest)(nil),         // 29: knowledge.v1.ListAllSpaceLinksRequest
-	(*ListAllSpaceLinksResponse)(nil),        // 30: knowledge.v1.ListAllSpaceLinksResponse
-	(*UpdateKnowledgeLinkRequest)(nil),       // 31: knowledge.v1.UpdateKnowledgeLinkRequest
-	(*DeleteKnowledgeLinkRequest)(nil),       // 32: knowledge.v1.DeleteKnowledgeLinkRequest
-	(*GetBacklinksRequest)(nil),              // 33: knowledge.v1.GetBacklinksRequest
-	(*GetBacklinksResponse)(nil),             // 34: knowledge.v1.GetBacklinksResponse
-	(*HealthStatus)(nil),                     // 35: knowledge.v1.HealthStatus
-	nil,                                      // 36: knowledge.v1.HealthStatus.ComponentsEntry
-	(*timestamppb.Timestamp)(nil),            // 37: google.protobuf.Timestamp
-	(*fieldmaskpb.FieldMask)(nil),            // 38: google.protobuf.FieldMask
-	(*emptypb.Empty)(nil),                    // 39: google.protobuf.Empty
+	(*DeleteContentSourceRequest)(nil),       // 23: knowledge.v1.DeleteContentSourceRequest
+	(*GenerateDownloadURLRequest)(nil),       // 24: knowledge.v1.GenerateDownloadURLRequest
+	(*GenerateDownloadURLResponse)(nil),      // 25: knowledge.v1.GenerateDownloadURLResponse
+	(*CreateKnowledgeLinkRequest)(nil),       // 26: knowledge.v1.CreateKnowledgeLinkRequest
+	(*GetKnowledgeLinkRequest)(nil),          // 27: knowledge.v1.GetKnowledgeLinkRequest
+	(*ListKnowledgeLinksRequest)(nil),        // 28: knowledge.v1.ListKnowledgeLinksRequest
+	(*ListKnowledgeLinksResponse)(nil),       // 29: knowledge.v1.ListKnowledgeLinksResponse
+	(*ListAllSpaceLinksRequest)(nil),         // 30: knowledge.v1.ListAllSpaceLinksRequest
+	(*ListAllSpaceLinksResponse)(nil),        // 31: knowledge.v1.ListAllSpaceLinksResponse
+	(*UpdateKnowledgeLinkRequest)(nil),       // 32: knowledge.v1.UpdateKnowledgeLinkRequest
+	(*DeleteKnowledgeLinkRequest)(nil),       // 33: knowledge.v1.DeleteKnowledgeLinkRequest
+	(*GetBacklinksRequest)(nil),              // 34: knowledge.v1.GetBacklinksRequest
+	(*GetBacklinksResponse)(nil),             // 35: knowledge.v1.GetBacklinksResponse
+	(*HealthStatus)(nil),                     // 36: knowledge.v1.HealthStatus
+	nil,                                      // 37: knowledge.v1.HealthStatus.ComponentsEntry
+	(*timestamppb.Timestamp)(nil),            // 38: google.protobuf.Timestamp
+	(*fieldmaskpb.FieldMask)(nil),            // 39: google.protobuf.FieldMask
+	(*emptypb.Empty)(nil),                    // 40: google.protobuf.Empty
 }
 var file_api_proto_v1_knowledge_proto_depIdxs = []int32{
-	37, // 0: knowledge.v1.SpaceStats.last_activity_at:type_name -> google.protobuf.Timestamp
+	38, // 0: knowledge.v1.SpaceStats.last_activity_at:type_name -> google.protobuf.Timestamp
 	4,  // 1: knowledge.v1.Space.stats:type_name -> knowledge.v1.SpaceStats
-	37, // 2: knowledge.v1.Space.created_at:type_name -> google.protobuf.Timestamp
-	37, // 3: knowledge.v1.Space.updated_at:type_name -> google.protobuf.Timestamp
+	38, // 2: knowledge.v1.Space.created_at:type_name -> google.protobuf.Timestamp
+	38, // 3: knowledge.v1.Space.updated_at:type_name -> google.protobuf.Timestamp
 	0,  // 4: knowledge.v1.ContentSource.status:type_name -> knowledge.v1.ContentStatus
-	37, // 5: knowledge.v1.ContentSource.created_at:type_name -> google.protobuf.Timestamp
-	37, // 6: knowledge.v1.ContentSource.updated_at:type_name -> google.protobuf.Timestamp
+	38, // 5: knowledge.v1.ContentSource.created_at:type_name -> google.protobuf.Timestamp
+	38, // 6: knowledge.v1.ContentSource.updated_at:type_name -> google.protobuf.Timestamp
 	1,  // 7: knowledge.v1.KnowledgeLink.relation_type:type_name -> knowledge.v1.RelationType
-	37, // 8: knowledge.v1.KnowledgeLink.created_at:type_name -> google.protobuf.Timestamp
-	37, // 9: knowledge.v1.KnowledgeLink.updated_at:type_name -> google.protobuf.Timestamp
+	38, // 8: knowledge.v1.KnowledgeLink.created_at:type_name -> google.protobuf.Timestamp
+	38, // 9: knowledge.v1.KnowledgeLink.updated_at:type_name -> google.protobuf.Timestamp
 	8,  // 10: knowledge.v1.EnrichedKnowledgeLink.from:type_name -> knowledge.v1.ContentPreview
 	8,  // 11: knowledge.v1.EnrichedKnowledgeLink.to:type_name -> knowledge.v1.ContentPreview
 	1,  // 12: knowledge.v1.EnrichedKnowledgeLink.relation_type:type_name -> knowledge.v1.RelationType
-	37, // 13: knowledge.v1.EnrichedKnowledgeLink.created_at:type_name -> google.protobuf.Timestamp
-	37, // 14: knowledge.v1.EnrichedKnowledgeLink.updated_at:type_name -> google.protobuf.Timestamp
-	37, // 15: knowledge.v1.ListSpacesRequest.created_after:type_name -> google.protobuf.Timestamp
-	37, // 16: knowledge.v1.ListSpacesRequest.created_before:type_name -> google.protobuf.Timestamp
-	37, // 17: knowledge.v1.ListSpacesRequest.updated_after:type_name -> google.protobuf.Timestamp
-	37, // 18: knowledge.v1.ListSpacesRequest.updated_before:type_name -> google.protobuf.Timestamp
+	38, // 13: knowledge.v1.EnrichedKnowledgeLink.created_at:type_name -> google.protobuf.Timestamp
+	38, // 14: knowledge.v1.EnrichedKnowledgeLink.updated_at:type_name -> google.protobuf.Timestamp
+	38, // 15: knowledge.v1.ListSpacesRequest.created_after:type_name -> google.protobuf.Timestamp
+	38, // 16: knowledge.v1.ListSpacesRequest.created_before:type_name -> google.protobuf.Timestamp
+	38, // 17: knowledge.v1.ListSpacesRequest.updated_after:type_name -> google.protobuf.Timestamp
+	38, // 18: knowledge.v1.ListSpacesRequest.updated_before:type_name -> google.protobuf.Timestamp
 	3,  // 19: knowledge.v1.ListSpacesRequest.page:type_name -> knowledge.v1.Pagination
 	5,  // 20: knowledge.v1.ListSpacesResponse.items:type_name -> knowledge.v1.Space
 	5,  // 21: knowledge.v1.UpdateSpaceRequest.space:type_name -> knowledge.v1.Space
-	38, // 22: knowledge.v1.UpdateSpaceRequest.update_mask:type_name -> google.protobuf.FieldMask
-	37, // 23: knowledge.v1.CreateUploadURLResponse.expires_at:type_name -> google.protobuf.Timestamp
+	39, // 22: knowledge.v1.UpdateSpaceRequest.update_mask:type_name -> google.protobuf.FieldMask
+	38, // 23: knowledge.v1.CreateUploadURLResponse.expires_at:type_name -> google.protobuf.Timestamp
 	6,  // 24: knowledge.v1.CreateUploadURLResponse.content_source:type_name -> knowledge.v1.ContentSource
 	0,  // 25: knowledge.v1.ListContentSourcesRequest.status:type_name -> knowledge.v1.ContentStatus
 	3,  // 26: knowledge.v1.ListContentSourcesRequest.page:type_name -> knowledge.v1.Pagination
 	6,  // 27: knowledge.v1.ListContentSourcesResponse.items:type_name -> knowledge.v1.ContentSource
 	0,  // 28: knowledge.v1.UpdateContentSourceStatusRequest.status:type_name -> knowledge.v1.ContentStatus
-	37, // 29: knowledge.v1.GenerateDownloadURLResponse.expires_at:type_name -> google.protobuf.Timestamp
+	38, // 29: knowledge.v1.GenerateDownloadURLResponse.expires_at:type_name -> google.protobuf.Timestamp
 	1,  // 30: knowledge.v1.CreateKnowledgeLinkRequest.relation_type:type_name -> knowledge.v1.RelationType
 	2,  // 31: knowledge.v1.ListKnowledgeLinksRequest.direction:type_name -> knowledge.v1.LinkDirection
 	1,  // 32: knowledge.v1.ListKnowledgeLinksRequest.relation_type:type_name -> knowledge.v1.RelationType
@@ -2647,10 +2695,10 @@ var file_api_proto_v1_knowledge_proto_depIdxs = []int32{
 	3,  // 36: knowledge.v1.ListAllSpaceLinksRequest.page:type_name -> knowledge.v1.Pagination
 	7,  // 37: knowledge.v1.ListAllSpaceLinksResponse.items:type_name -> knowledge.v1.KnowledgeLink
 	7,  // 38: knowledge.v1.UpdateKnowledgeLinkRequest.link:type_name -> knowledge.v1.KnowledgeLink
-	38, // 39: knowledge.v1.UpdateKnowledgeLinkRequest.update_mask:type_name -> google.protobuf.FieldMask
+	39, // 39: knowledge.v1.UpdateKnowledgeLinkRequest.update_mask:type_name -> google.protobuf.FieldMask
 	3,  // 40: knowledge.v1.GetBacklinksRequest.page:type_name -> knowledge.v1.Pagination
 	7,  // 41: knowledge.v1.GetBacklinksResponse.items:type_name -> knowledge.v1.KnowledgeLink
-	36, // 42: knowledge.v1.HealthStatus.components:type_name -> knowledge.v1.HealthStatus.ComponentsEntry
+	37, // 42: knowledge.v1.HealthStatus.components:type_name -> knowledge.v1.HealthStatus.ComponentsEntry
 	10, // 43: knowledge.v1.KnowledgeService.CreateSpace:input_type -> knowledge.v1.CreateSpaceRequest
 	11, // 44: knowledge.v1.KnowledgeService.GetSpace:input_type -> knowledge.v1.GetSpaceRequest
 	12, // 45: knowledge.v1.KnowledgeService.ListSpaces:input_type -> knowledge.v1.ListSpacesRequest
@@ -2661,36 +2709,38 @@ var file_api_proto_v1_knowledge_proto_depIdxs = []int32{
 	19, // 50: knowledge.v1.KnowledgeService.GetContentSource:input_type -> knowledge.v1.GetContentSourceRequest
 	20, // 51: knowledge.v1.KnowledgeService.ListContentSources:input_type -> knowledge.v1.ListContentSourcesRequest
 	22, // 52: knowledge.v1.KnowledgeService.UpdateContentSourceStatus:input_type -> knowledge.v1.UpdateContentSourceStatusRequest
-	23, // 53: knowledge.v1.KnowledgeService.GenerateDownloadURL:input_type -> knowledge.v1.GenerateDownloadURLRequest
-	25, // 54: knowledge.v1.KnowledgeService.CreateKnowledgeLink:input_type -> knowledge.v1.CreateKnowledgeLinkRequest
-	26, // 55: knowledge.v1.KnowledgeService.GetKnowledgeLink:input_type -> knowledge.v1.GetKnowledgeLinkRequest
-	27, // 56: knowledge.v1.KnowledgeService.ListKnowledgeLinks:input_type -> knowledge.v1.ListKnowledgeLinksRequest
-	29, // 57: knowledge.v1.KnowledgeService.ListAllSpaceLinks:input_type -> knowledge.v1.ListAllSpaceLinksRequest
-	31, // 58: knowledge.v1.KnowledgeService.UpdateKnowledgeLink:input_type -> knowledge.v1.UpdateKnowledgeLinkRequest
-	32, // 59: knowledge.v1.KnowledgeService.DeleteKnowledgeLink:input_type -> knowledge.v1.DeleteKnowledgeLinkRequest
-	33, // 60: knowledge.v1.KnowledgeService.GetBacklinks:input_type -> knowledge.v1.GetBacklinksRequest
-	39, // 61: knowledge.v1.KnowledgeService.Healthz:input_type -> google.protobuf.Empty
-	5,  // 62: knowledge.v1.KnowledgeService.CreateSpace:output_type -> knowledge.v1.Space
-	5,  // 63: knowledge.v1.KnowledgeService.GetSpace:output_type -> knowledge.v1.Space
-	13, // 64: knowledge.v1.KnowledgeService.ListSpaces:output_type -> knowledge.v1.ListSpacesResponse
-	5,  // 65: knowledge.v1.KnowledgeService.UpdateSpace:output_type -> knowledge.v1.Space
-	39, // 66: knowledge.v1.KnowledgeService.DeleteSpace:output_type -> google.protobuf.Empty
-	17, // 67: knowledge.v1.KnowledgeService.CreateUploadURL:output_type -> knowledge.v1.CreateUploadURLResponse
-	6,  // 68: knowledge.v1.KnowledgeService.ConfirmUpload:output_type -> knowledge.v1.ContentSource
-	6,  // 69: knowledge.v1.KnowledgeService.GetContentSource:output_type -> knowledge.v1.ContentSource
-	21, // 70: knowledge.v1.KnowledgeService.ListContentSources:output_type -> knowledge.v1.ListContentSourcesResponse
-	6,  // 71: knowledge.v1.KnowledgeService.UpdateContentSourceStatus:output_type -> knowledge.v1.ContentSource
-	24, // 72: knowledge.v1.KnowledgeService.GenerateDownloadURL:output_type -> knowledge.v1.GenerateDownloadURLResponse
-	7,  // 73: knowledge.v1.KnowledgeService.CreateKnowledgeLink:output_type -> knowledge.v1.KnowledgeLink
-	9,  // 74: knowledge.v1.KnowledgeService.GetKnowledgeLink:output_type -> knowledge.v1.EnrichedKnowledgeLink
-	28, // 75: knowledge.v1.KnowledgeService.ListKnowledgeLinks:output_type -> knowledge.v1.ListKnowledgeLinksResponse
-	30, // 76: knowledge.v1.KnowledgeService.ListAllSpaceLinks:output_type -> knowledge.v1.ListAllSpaceLinksResponse
-	7,  // 77: knowledge.v1.KnowledgeService.UpdateKnowledgeLink:output_type -> knowledge.v1.KnowledgeLink
-	39, // 78: knowledge.v1.KnowledgeService.DeleteKnowledgeLink:output_type -> google.protobuf.Empty
-	34, // 79: knowledge.v1.KnowledgeService.GetBacklinks:output_type -> knowledge.v1.GetBacklinksResponse
-	35, // 80: knowledge.v1.KnowledgeService.Healthz:output_type -> knowledge.v1.HealthStatus
-	62, // [62:81] is the sub-list for method output_type
-	43, // [43:62] is the sub-list for method input_type
+	23, // 53: knowledge.v1.KnowledgeService.DeleteContentSource:input_type -> knowledge.v1.DeleteContentSourceRequest
+	24, // 54: knowledge.v1.KnowledgeService.GenerateDownloadURL:input_type -> knowledge.v1.GenerateDownloadURLRequest
+	26, // 55: knowledge.v1.KnowledgeService.CreateKnowledgeLink:input_type -> knowledge.v1.CreateKnowledgeLinkRequest
+	27, // 56: knowledge.v1.KnowledgeService.GetKnowledgeLink:input_type -> knowledge.v1.GetKnowledgeLinkRequest
+	28, // 57: knowledge.v1.KnowledgeService.ListKnowledgeLinks:input_type -> knowledge.v1.ListKnowledgeLinksRequest
+	30, // 58: knowledge.v1.KnowledgeService.ListAllSpaceLinks:input_type -> knowledge.v1.ListAllSpaceLinksRequest
+	32, // 59: knowledge.v1.KnowledgeService.UpdateKnowledgeLink:input_type -> knowledge.v1.UpdateKnowledgeLinkRequest
+	33, // 60: knowledge.v1.KnowledgeService.DeleteKnowledgeLink:input_type -> knowledge.v1.DeleteKnowledgeLinkRequest
+	34, // 61: knowledge.v1.KnowledgeService.GetBacklinks:input_type -> knowledge.v1.GetBacklinksRequest
+	40, // 62: knowledge.v1.KnowledgeService.Healthz:input_type -> google.protobuf.Empty
+	5,  // 63: knowledge.v1.KnowledgeService.CreateSpace:output_type -> knowledge.v1.Space
+	5,  // 64: knowledge.v1.KnowledgeService.GetSpace:output_type -> knowledge.v1.Space
+	13, // 65: knowledge.v1.KnowledgeService.ListSpaces:output_type -> knowledge.v1.ListSpacesResponse
+	5,  // 66: knowledge.v1.KnowledgeService.UpdateSpace:output_type -> knowledge.v1.Space
+	40, // 67: knowledge.v1.KnowledgeService.DeleteSpace:output_type -> google.protobuf.Empty
+	17, // 68: knowledge.v1.KnowledgeService.CreateUploadURL:output_type -> knowledge.v1.CreateUploadURLResponse
+	6,  // 69: knowledge.v1.KnowledgeService.ConfirmUpload:output_type -> knowledge.v1.ContentSource
+	6,  // 70: knowledge.v1.KnowledgeService.GetContentSource:output_type -> knowledge.v1.ContentSource
+	21, // 71: knowledge.v1.KnowledgeService.ListContentSources:output_type -> knowledge.v1.ListContentSourcesResponse
+	6,  // 72: knowledge.v1.KnowledgeService.UpdateContentSourceStatus:output_type -> knowledge.v1.ContentSource
+	40, // 73: knowledge.v1.KnowledgeService.DeleteContentSource:output_type -> google.protobuf.Empty
+	25, // 74: knowledge.v1.KnowledgeService.GenerateDownloadURL:output_type -> knowledge.v1.GenerateDownloadURLResponse
+	7,  // 75: knowledge.v1.KnowledgeService.CreateKnowledgeLink:output_type -> knowledge.v1.KnowledgeLink
+	9,  // 76: knowledge.v1.KnowledgeService.GetKnowledgeLink:output_type -> knowledge.v1.EnrichedKnowledgeLink
+	29, // 77: knowledge.v1.KnowledgeService.ListKnowledgeLinks:output_type -> knowledge.v1.ListKnowledgeLinksResponse
+	31, // 78: knowledge.v1.KnowledgeService.ListAllSpaceLinks:output_type -> knowledge.v1.ListAllSpaceLinksResponse
+	7,  // 79: knowledge.v1.KnowledgeService.UpdateKnowledgeLink:output_type -> knowledge.v1.KnowledgeLink
+	40, // 80: knowledge.v1.KnowledgeService.DeleteKnowledgeLink:output_type -> google.protobuf.Empty
+	35, // 81: knowledge.v1.KnowledgeService.GetBacklinks:output_type -> knowledge.v1.GetBacklinksResponse
+	36, // 82: knowledge.v1.KnowledgeService.Healthz:output_type -> knowledge.v1.HealthStatus
+	63, // [63:83] is the sub-list for method output_type
+	43, // [43:63] is the sub-list for method input_type
 	43, // [43:43] is the sub-list for extension type_name
 	43, // [43:43] is the sub-list for extension extendee
 	0,  // [0:43] is the sub-list for field type_name
@@ -2707,7 +2757,7 @@ func file_api_proto_v1_knowledge_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_proto_v1_knowledge_proto_rawDesc), len(file_api_proto_v1_knowledge_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   34,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/ms_knowledge/api/proto/v1/knowledge.proto
+++ b/ms_knowledge/api/proto/v1/knowledge.proto
@@ -23,6 +23,7 @@ service KnowledgeService {
   rpc GetContentSource(GetContentSourceRequest) returns (ContentSource);
   rpc ListContentSources(ListContentSourcesRequest) returns (ListContentSourcesResponse);
   rpc UpdateContentSourceStatus(UpdateContentSourceStatusRequest) returns (ContentSource);
+  rpc DeleteContentSource(DeleteContentSourceRequest) returns (google.protobuf.Empty);
   // Download URL Generation
   rpc GenerateDownloadURL(GenerateDownloadURLRequest) returns (GenerateDownloadURLResponse);
 
@@ -219,6 +220,10 @@ message UpdateContentSourceStatusRequest {
   ContentStatus status = 2;
   string processed_blob_hash = 3;
   string error_message = 4;
+}
+
+message DeleteContentSourceRequest {
+  string id = 1;
 }
 
 // Download URL generation

--- a/ms_knowledge/api/proto/v1/knowledge_grpc.pb.go
+++ b/ms_knowledge/api/proto/v1/knowledge_grpc.pb.go
@@ -30,6 +30,7 @@ const (
 	KnowledgeService_GetContentSource_FullMethodName          = "/knowledge.v1.KnowledgeService/GetContentSource"
 	KnowledgeService_ListContentSources_FullMethodName        = "/knowledge.v1.KnowledgeService/ListContentSources"
 	KnowledgeService_UpdateContentSourceStatus_FullMethodName = "/knowledge.v1.KnowledgeService/UpdateContentSourceStatus"
+	KnowledgeService_DeleteContentSource_FullMethodName       = "/knowledge.v1.KnowledgeService/DeleteContentSource"
 	KnowledgeService_GenerateDownloadURL_FullMethodName       = "/knowledge.v1.KnowledgeService/GenerateDownloadURL"
 	KnowledgeService_CreateKnowledgeLink_FullMethodName       = "/knowledge.v1.KnowledgeService/CreateKnowledgeLink"
 	KnowledgeService_GetKnowledgeLink_FullMethodName          = "/knowledge.v1.KnowledgeService/GetKnowledgeLink"
@@ -59,6 +60,7 @@ type KnowledgeServiceClient interface {
 	GetContentSource(ctx context.Context, in *GetContentSourceRequest, opts ...grpc.CallOption) (*ContentSource, error)
 	ListContentSources(ctx context.Context, in *ListContentSourcesRequest, opts ...grpc.CallOption) (*ListContentSourcesResponse, error)
 	UpdateContentSourceStatus(ctx context.Context, in *UpdateContentSourceStatusRequest, opts ...grpc.CallOption) (*ContentSource, error)
+	DeleteContentSource(ctx context.Context, in *DeleteContentSourceRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Download URL Generation
 	GenerateDownloadURL(ctx context.Context, in *GenerateDownloadURLRequest, opts ...grpc.CallOption) (*GenerateDownloadURLResponse, error)
 	// Knowledge Graph Management
@@ -184,6 +186,16 @@ func (c *knowledgeServiceClient) UpdateContentSourceStatus(ctx context.Context, 
 	return out, nil
 }
 
+func (c *knowledgeServiceClient) DeleteContentSource(ctx context.Context, in *DeleteContentSourceRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, KnowledgeService_DeleteContentSource_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *knowledgeServiceClient) GenerateDownloadURL(ctx context.Context, in *GenerateDownloadURLRequest, opts ...grpc.CallOption) (*GenerateDownloadURLResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GenerateDownloadURLResponse)
@@ -292,6 +304,7 @@ type KnowledgeServiceServer interface {
 	GetContentSource(context.Context, *GetContentSourceRequest) (*ContentSource, error)
 	ListContentSources(context.Context, *ListContentSourcesRequest) (*ListContentSourcesResponse, error)
 	UpdateContentSourceStatus(context.Context, *UpdateContentSourceStatusRequest) (*ContentSource, error)
+	DeleteContentSource(context.Context, *DeleteContentSourceRequest) (*emptypb.Empty, error)
 	// Download URL Generation
 	GenerateDownloadURL(context.Context, *GenerateDownloadURLRequest) (*GenerateDownloadURLResponse, error)
 	// Knowledge Graph Management
@@ -346,6 +359,9 @@ func (UnimplementedKnowledgeServiceServer) ListContentSources(context.Context, *
 }
 func (UnimplementedKnowledgeServiceServer) UpdateContentSourceStatus(context.Context, *UpdateContentSourceStatusRequest) (*ContentSource, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateContentSourceStatus not implemented")
+}
+func (UnimplementedKnowledgeServiceServer) DeleteContentSource(context.Context, *DeleteContentSourceRequest) (*emptypb.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteContentSource not implemented")
 }
 func (UnimplementedKnowledgeServiceServer) GenerateDownloadURL(context.Context, *GenerateDownloadURLRequest) (*GenerateDownloadURLResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GenerateDownloadURL not implemented")
@@ -575,6 +591,24 @@ func _KnowledgeService_UpdateContentSourceStatus_Handler(srv interface{}, ctx co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _KnowledgeService_DeleteContentSource_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteContentSourceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(KnowledgeServiceServer).DeleteContentSource(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: KnowledgeService_DeleteContentSource_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(KnowledgeServiceServer).DeleteContentSource(ctx, req.(*DeleteContentSourceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _KnowledgeService_GenerateDownloadURL_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GenerateDownloadURLRequest)
 	if err := dec(in); err != nil {
@@ -783,6 +817,10 @@ var KnowledgeService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateContentSourceStatus",
 			Handler:    _KnowledgeService_UpdateContentSourceStatus_Handler,
+		},
+		{
+			MethodName: "DeleteContentSource",
+			Handler:    _KnowledgeService_DeleteContentSource_Handler,
 		},
 		{
 			MethodName: "GenerateDownloadURL",

--- a/ms_knowledge/internal/server/grpc.go
+++ b/ms_knowledge/internal/server/grpc.go
@@ -246,6 +246,33 @@ func (s *GRPCServer) GetContentSource(ctx context.Context, req *knowledgev1.GetC
 	return s.domainContentSourceToProto(content), nil
 }
 
+func (s *GRPCServer) DeleteContentSource(ctx context.Context, req *knowledgev1.DeleteContentSourceRequest) (*emptypb.Empty, error) {
+	id, err := uuid.Parse(req.Id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid content source id: %v", err)
+	}
+
+	// RBAC/Ownership: admins bypass, others must own the content source
+	if role, ok := ctx.Value(domain.RoleKey).(string); !(ok && role == "admin") {
+		if md, ok := metadata.FromIncomingContext(ctx); ok && s.userClient != nil {
+			outCtx := metadata.NewOutgoingContext(ctx, md)
+			uReq := &userv1.GetUserRequest{}
+			if uResp, err := s.userClient.GetUser(outCtx, uReq); err == nil && uResp.GetUser() != nil {
+				ownerID := uResp.GetUser().GetId()
+				cs, _ := s.contentService.GetContentSource(ctx, id)
+				if cs != nil && cs.OwnerID.String() != ownerID {
+					return nil, status.Errorf(codes.PermissionDenied, "not owner")
+				}
+			}
+		}
+	}
+
+	if err := s.contentService.DeleteContentSource(ctx, id); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to delete content source: %v", err)
+	}
+	return &emptypb.Empty{}, nil
+}
+
 func (s *GRPCServer) ListContentSources(ctx context.Context, req *knowledgev1.ListContentSourcesRequest) (*knowledgev1.ListContentSourcesResponse, error) {
 	spaceID, err := uuid.Parse(req.SpaceId)
 	if err != nil {

--- a/ms_knowledge/internal/service/content_service.go
+++ b/ms_knowledge/internal/service/content_service.go
@@ -349,9 +349,9 @@ func (s *ContentService) DeleteContentSource(ctx context.Context, id uuid.UUID) 
 		return fmt.Errorf("failed to get content source: %w", err)
 	}
 
-	bucket := s.sourceBucket
-	if bucket == "" {
-		bucket = "knowledge-content"
+	bucket, err := s.resolveBucket("source")
+	if err != nil {
+		return fmt.Errorf("failed to resolve source bucket: %w", err)
 	}
 
 	filename := strings.TrimSpace(content.Source)

--- a/ms_knowledge/internal/service/content_service.go
+++ b/ms_knowledge/internal/service/content_service.go
@@ -32,6 +32,7 @@ type StorageService interface {
 	GeneratePresignedUploadURL(bucket, key string, expires time.Duration) (string, error)
 	CalculateSHA256(data []byte) string
 	GeneratePresignedDownloadURL(bucket, key string, expires time.Duration) (string, error)
+	DeleteObject(bucket, key string) error
 }
 
 // NewContentService constructs the service. Pass nil producer if events are not needed (e.g., tests).
@@ -289,4 +290,30 @@ func (s *ContentService) GenerateDownloadURL(ctx context.Context, contentID uuid
 	}
 
 	return url, time.Now().Add(expires), nil
+}
+
+// DeleteContentSource deletes the source object in R2 (best-effort) and removes the DB row.
+func (s *ContentService) DeleteContentSource(ctx context.Context, id uuid.UUID) error {
+	content, err := s.contentRepo.GetByID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to get content source: %w", err)
+	}
+
+	bucket := s.sourceBucket
+	if bucket == "" {
+		bucket = "knowledge-content"
+	}
+
+	filename := strings.TrimSpace(content.Source)
+	objectKey := fmt.Sprintf("spaces/%s/content/%s/%s", content.SpaceID.String(), content.ID.String(), filename)
+
+	if err := s.storage.DeleteObject(bucket, objectKey); err != nil {
+		s.logger.Printf("WARN: failed to delete R2 object (bucket=%s key=%s): %v", bucket, objectKey, err)
+	}
+
+	if err := s.contentRepo.Delete(ctx, id); err != nil {
+		return fmt.Errorf("failed to delete content source from DB: %w", err)
+	}
+
+	return nil
 }

--- a/ms_knowledge/internal/service/content_service_test.go
+++ b/ms_knowledge/internal/service/content_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -12,6 +13,11 @@ import (
 
 	"github.com/google/uuid"
 )
+
+// erroringStorage implements StorageService and returns an error on DeleteObject
+type erroringStorage struct{ mockStorage }
+
+func (e *erroringStorage) DeleteObject(bucket, key string) error { return fmt.Errorf("boom") }
 
 func TestCreateUploadURL_Validation(t *testing.T) {
 	contentRepo := newMockContentRepo()
@@ -116,5 +122,59 @@ func TestUpdateContentSourceStatus(t *testing.T) {
 	}
 	if res.ProcessedBlobHash == nil || *res.ProcessedBlobHash != "processed-hash" {
 		t.Fatalf("expected processed hash to be set")
+	}
+}
+
+func TestDeleteContentSource_DeletesR2AndDB(t *testing.T) {
+	contentRepo := newMockContentRepo()
+	spaceRepo := newMockSpaceRepo()
+	graphRepo := newMockGraphRepo()
+	storage := &mockStorage{}
+	svc := NewContentService(contentRepo, spaceRepo, graphRepo, storage, nil, "knowledge-source", log.New(os.Stdout, "", log.LstdFlags))
+
+	ctx := context.Background()
+	space := &domain.Space{ID: uuid.New(), Title: "s", OwnerID: uuid.New(), CreatedAt: time.Now(), LastUpdatedAt: time.Now()}
+	_ = spaceRepo.Create(ctx, space)
+
+	item := &domain.ContentSource{ID: uuid.New(), SpaceID: space.ID, Title: "Doc", MediaType: "text/plain", Source: "file.txt", Status: domain.ContentStatusUploaded}
+	_ = contentRepo.Create(ctx, item)
+
+	if err := svc.DeleteContentSource(ctx, item.ID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if exists, _ := contentRepo.Exists(ctx, item.ID); exists {
+		t.Fatalf("expected DB row to be deleted")
+	}
+
+	if len(storage.deleted) != 1 {
+		t.Fatalf("expected one delete call to storage, got %d", len(storage.deleted))
+	}
+	d := storage.deleted[0]
+	expectedKey := "spaces/" + space.ID.String() + "/content/" + item.ID.String() + "/file.txt"
+	if d.bucket != "knowledge-source" || d.key != expectedKey {
+		t.Fatalf("unexpected delete args: bucket=%s key=%s", d.bucket, d.key)
+	}
+}
+
+func TestDeleteContentSource_ObjectDeleteFailsButDBStillRemoved(t *testing.T) {
+	contentRepo := newMockContentRepo()
+	spaceRepo := newMockSpaceRepo()
+	graphRepo := newMockGraphRepo()
+	errStorage := &erroringStorage{}
+	svc := NewContentService(contentRepo, spaceRepo, graphRepo, errStorage, nil, "knowledge-source", log.New(os.Stdout, "", log.LstdFlags))
+
+	ctx := context.Background()
+	space := &domain.Space{ID: uuid.New(), Title: "s", OwnerID: uuid.New(), CreatedAt: time.Now(), LastUpdatedAt: time.Now()}
+	_ = spaceRepo.Create(ctx, space)
+
+	item := &domain.ContentSource{ID: uuid.New(), SpaceID: space.ID, Title: "Doc", MediaType: "text/plain", Source: "file.txt", Status: domain.ContentStatusUploaded}
+	_ = contentRepo.Create(ctx, item)
+
+	if err := svc.DeleteContentSource(ctx, item.ID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exists, _ := contentRepo.Exists(ctx, item.ID); exists {
+		t.Fatalf("expected DB row to be deleted even if object delete fails")
 	}
 }

--- a/ms_knowledge/internal/service/content_service_test.go
+++ b/ms_knowledge/internal/service/content_service_test.go
@@ -143,7 +143,10 @@ func TestDeleteContentSource_DeletesR2AndDB(t *testing.T) {
 	spaceRepo := newMockSpaceRepo()
 	graphRepo := newMockGraphRepo()
 	storage := &mockStorage{}
-	svc := NewContentService(contentRepo, spaceRepo, graphRepo, storage, nil, "knowledge-source", log.New(os.Stdout, "", log.LstdFlags))
+	cfg := &config.Config{}
+	cfg.R2.BucketSourceName = "knowledge-source"
+	cfg.R2.BucketProcessedName = "test-processed"
+	svc := NewContentService(contentRepo, spaceRepo, graphRepo, storage, nil, cfg, log.New(os.Stdout, "", log.LstdFlags))
 
 	ctx := context.Background()
 	space := &domain.Space{ID: uuid.New(), Title: "s", OwnerID: uuid.New(), CreatedAt: time.Now(), LastUpdatedAt: time.Now()}
@@ -175,7 +178,10 @@ func TestDeleteContentSource_ObjectDeleteFailsButDBStillRemoved(t *testing.T) {
 	spaceRepo := newMockSpaceRepo()
 	graphRepo := newMockGraphRepo()
 	errStorage := &erroringStorage{}
-	svc := NewContentService(contentRepo, spaceRepo, graphRepo, errStorage, nil, "knowledge-source", log.New(os.Stdout, "", log.LstdFlags))
+	cfg := &config.Config{}
+	cfg.R2.BucketSourceName = "knowledge-source"
+	cfg.R2.BucketProcessedName = "test-processed"
+	svc := NewContentService(contentRepo, spaceRepo, graphRepo, errStorage, nil, cfg, log.New(os.Stdout, "", log.LstdFlags))
 
 	ctx := context.Background()
 	space := &domain.Space{ID: uuid.New(), Title: "s", OwnerID: uuid.New(), CreatedAt: time.Now(), LastUpdatedAt: time.Now()}

--- a/ms_knowledge/internal/service/mocks_test.go
+++ b/ms_knowledge/internal/service/mocks_test.go
@@ -63,7 +63,7 @@ func (m *mockSpaceRepo) GetWithStats(ctx context.Context, id uuid.UUID) (*domain
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return &domain.SpaceWithStats{Space: *sp, Stats: domain.SpaceStats{
 		ContentCount: 1, // For testing - assume 1 content per space
 	}}, nil
@@ -345,7 +345,9 @@ func (m *mockGraphRepo) ListKnowledgeLinksBySpace(ctx context.Context, spaceID u
 }
 
 // mockStorage implements StorageService for tests
-type mockStorage struct{}
+type mockStorage struct {
+	deleted []struct{ bucket, key string }
+}
 
 func (m *mockStorage) GeneratePresignedUploadURL(bucket, key string, expires time.Duration) (string, error) {
 	return fmt.Sprintf("https://example.com/%s", key), nil
@@ -354,4 +356,13 @@ func (m *mockStorage) GeneratePresignedUploadURL(bucket, key string, expires tim
 func (m *mockStorage) CalculateSHA256(data []byte) string {
 	sha := sha256.Sum256(data)
 	return hex.EncodeToString(sha[:])
+}
+
+func (m *mockStorage) GeneratePresignedDownloadURL(bucket, key string, expires time.Duration) (string, error) {
+	return fmt.Sprintf("https://example.com/%s", key), nil
+}
+
+func (m *mockStorage) DeleteObject(bucket, key string) error {
+	m.deleted = append(m.deleted, struct{ bucket, key string }{bucket: bucket, key: key})
+	return nil
 }

--- a/ms_knowledge/internal/storage/r2/adapter.go
+++ b/ms_knowledge/internal/storage/r2/adapter.go
@@ -25,3 +25,7 @@ func (a *Adapter) CalculateSHA256(data []byte) string {
 func (a *Adapter) GeneratePresignedDownloadURL(bucket, key string, expires time.Duration) (string, error) {
 	return a.client.GeneratePresignedDownloadURL(context.Background(), bucket, key, expires)
 }
+
+func (a *Adapter) DeleteObject(bucket, key string) error {
+	return a.client.DeleteObject(context.Background(), bucket, key)
+}

--- a/ms_knowledge/internal/storage/r2/client.go
+++ b/ms_knowledge/internal/storage/r2/client.go
@@ -125,6 +125,15 @@ func (c *Client) GeneratePresignedDownloadURL(ctx context.Context, bucket, key s
 	return req.URL, nil
 }
 
+// DeleteObject removes the object at bucket/key from R2.
+func (c *Client) DeleteObject(ctx context.Context, bucket, key string) error {
+	_, err := c.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	return err
+}
+
 // CalculateSHA256 returns the hex-encoded sha256 of data.
 func CalculateSHA256(data []byte) string {
 	sum := sha256.Sum256(data)


### PR DESCRIPTION
## Summary
- **Feature**: Hard delete for Content Sources (DB row + R2 object) via new gRPC.
- **Scope**: Proto addition, server handler (RBAC), service orchestration, R2 delete support, docs/codegen fix, unit tests.

## Requirements Covered
- Delete operation for Content Sources (no soft delete; confirm on UI)
- Ensure blob storage (R2) object is removed along with DB record

## Implementation Details
- **Proto**
  - Added `DeleteContentSource(DeleteContentSourceRequest) returns (google.protobuf.Empty)` to `KnowledgeService`.
- **Server (gRPC)**
  - Implemented `DeleteContentSource` with admin bypass and owner check (mirrors `DeleteSpace`).
- **Service**
  - `ContentService.DeleteContentSource`: derives object key, deletes R2 object (best-effort), then deletes DB row.
- **Storage (R2)**
  - Added `DeleteObject` to client and adapter.
- **Docs**
  - Updated `docs/coding-guide/BACKEND.md` to correct protoc codegen commands (emit .pb.go next to .proto).

## Changed Files (selected)
```
ms_knowledge/api/proto/v1/knowledge.proto                  (M)
ms_knowledge/api/proto/v1/knowledge_grpc.pb.go             (M)
ms_knowledge/api/proto/v1/knowledge.pb.go                  (M)
ms_knowledge/internal/server/grpc.go                       (M)
ms_knowledge/internal/service/content_service.go           (M)
ms_knowledge/internal/storage/r2/client.go                 (M)
ms_knowledge/internal/storage/r2/adapter.go                (M)
ms_knowledge/internal/service/content_service_test.go      (+)
ms_knowledge/internal/service/mocks_test.go                (M)
docs/coding-guide/BACKEND.md                               (M)
```

## Testing Instructions
1. Build: `cd ms_knowledge && go build ./...` (should succeed).
2. Unit tests: `go test ./...` (service tests pass; deletion covered).
3. Optional: Call gRPC via client/grpcurl – `DeleteContentSource(id)` removes DB row and R2 object.

## Notes
- Deletion is hard-delete only; UI must present a confirmation dialog before invoking.
- If R2 delete fails, DB delete still proceeds and a warning is logged.

## Checklist
- [x] Proto updated and stubs regenerated to same dir as .proto
- [x] Server handler with RBAC implemented
- [x] Service orchestrates R2 + DB deletion
- [x] Docs updated for protoc generation
- [x] Unit tests added and passing
- [x] Build green; no new linter errors
