### PR TITLE
Refactor: Simplified Object Key Management

### DIFF
--- a/ms_document_process/app/repository/document_repository.py
+++ b/ms_document_process/app/repository/document_repository.py
@@ -7,17 +7,18 @@ class DocumentRepository:
     """
     def __init__(self, r2_client: R2Client):
         self.r2_client = r2_client
+        # Use separate buckets for source and processed documents
         self.source_bucket = settings.r2_bucket_source_name
         self.processed_bucket = settings.r2_bucket_processed_name
 
-    def download_source_document(self, blob_hash: str) -> bytes:
+    def download_source_document(self, object_key: str) -> bytes:
         """
-        Downloads the original document from the source bucket.
+        Downloads the original document from the source bucket using the full object key.
         """
-        return self.r2_client.download_file(self.source_bucket, blob_hash)
+        return self.r2_client.download_file(self.source_bucket, object_key)
 
-    def upload_processed_document(self, blob_hash: str, data: bytes, content_type: str = 'text/markdown') -> None:
+    def upload_processed_document(self, object_key: str, data: bytes, content_type: str = 'text/markdown') -> None:
         """
         Uploads the processed document (e.g., Markdown) to the processed bucket.
         """
-        self.r2_client.upload_file(self.processed_bucket, blob_hash, data, content_type)
+        self.r2_client.upload_file(self.processed_bucket, object_key, data, content_type)

--- a/ms_document_process/app/service/document_service.py
+++ b/ms_document_process/app/service/document_service.py
@@ -44,8 +44,11 @@ class DocumentProcessService:
     def process_document(self, event: DocumentUploadedEvent):
         logger.info(f"Processing document for content_source_id: {event.content_source_id}")
         try:
-            # Determine key to fetch original (prefer object key if present)
-            source_key = event.original_object_key if getattr(event, 'original_object_key', None) else event.original_blob_hash
+            # Determine key to fetch original - use object key for consistent path structure
+            if not event.original_object_key:
+                logger.error(f"Missing original_object_key for content_source_id: {event.content_source_id}")
+                raise ValueError(f"original_object_key is required for processing content_source_id: {event.content_source_id}")
+            source_key = event.original_object_key
 
             # Download the document from R2 (with retries)
             document_content = self._retry_with_backoff(

--- a/ms_document_process/app/service/document_service.py
+++ b/ms_document_process/app/service/document_service.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 # Encoding constant for consistent text encoding throughout the service
 ENCODING = 'utf-8'
 
+
 class DocumentProcessService:
     def __init__(self, document_repository: DocumentRepository, kafka_producer: KafkaProducer):
         self.document_repository = document_repository
@@ -60,15 +61,13 @@ class DocumentProcessService:
                 lambda: convert_document_to_markdown(document_content, "pdf"),
             )
 
-            # Calculate the hash of the processed content
+            # Calculate the hash of the processed content (metadata)
             processed_blob_hash = hashlib.sha256(markdown_content.encode(ENCODING)).hexdigest()
 
-            # Upload the processed document to R2
-            # Upload the processed document (with retries)
             self._retry_with_backoff(
                 "upload_processed_document",
                 lambda: self.document_repository.upload_processed_document(
-                    processed_blob_hash, markdown_content.encode(ENCODING)
+                    source_key, markdown_content.encode(ENCODING)
                 ),
             )
 

--- a/ms_document_process/tests/test_document_service.py
+++ b/ms_document_process/tests/test_document_service.py
@@ -19,10 +19,17 @@ class TestDocumentProcessService(unittest.TestCase):
     @patch('app.service.document_service.convert_document_to_markdown')
     def test_process_document_success(self, mock_convert):
         # Arrange
+        content_source_id = uuid4()
+        space_id = uuid4()
+        owner_id = uuid4()
+        filename = "test-document.pdf"
+        object_key = f"{owner_id}/spaces/{space_id}/content/{content_source_id}/{filename}"
+        
         event = DocumentUploadedEvent(
-            content_source_id=uuid4(),
+            content_source_id=content_source_id,
             original_blob_hash='original_hash',
-            space_id=uuid4()
+            space_id=space_id,
+            original_object_key=object_key
         )
         document_content = b'pdf content'
         markdown_content = '# Markdown'
@@ -35,10 +42,10 @@ class TestDocumentProcessService(unittest.TestCase):
         self.service.process_document(event)
 
         # Assert
-        self.mock_document_repository.download_source_document.assert_called_once_with('original_hash')
+        self.mock_document_repository.download_source_document.assert_called_once_with(object_key)
         mock_convert.assert_called_once_with(document_content, 'pdf')
         self.mock_document_repository.upload_processed_document.assert_called_once_with(
-            processed_hash, markdown_content.encode('utf-8')
+            object_key, markdown_content.encode('utf-8')
         )
         
         # Check that the success event was produced
@@ -50,10 +57,17 @@ class TestDocumentProcessService(unittest.TestCase):
 
     def test_process_document_failure(self):
         # Arrange
+        content_source_id = uuid4()
+        space_id = uuid4()
+        owner_id = uuid4()
+        filename = "test-document.pdf"
+        object_key = f"{owner_id}/spaces/{space_id}/content/{content_source_id}/{filename}"
+        
         event = DocumentUploadedEvent(
-            content_source_id=uuid4(),
+            content_source_id=content_source_id,
             original_blob_hash='original_hash',
-            space_id=uuid4()
+            space_id=space_id,
+            original_object_key=object_key
         )
         self.mock_document_repository.download_source_document.side_effect = Exception("Download failed")
 
@@ -66,7 +80,25 @@ class TestDocumentProcessService(unittest.TestCase):
         produced_event = self.mock_kafka_producer.produce_document_processed_event.call_args[0][0]
         self.assertIsInstance(produced_event, DocumentProcessedEvent)
         self.assertEqual(produced_event.status, "FAILED")
-        self.assertIsNotNone(produced_event.error_message)
+
+    def test_process_document_missing_object_key(self):
+        # Arrange - event without original_object_key
+        event = DocumentUploadedEvent(
+            content_source_id=uuid4(),
+            original_blob_hash='original_hash',
+            space_id=uuid4()
+            # original_object_key is intentionally omitted
+        )
+
+        # Act
+        self.service.process_document(event)
+
+        # Assert - should produce failure event due to missing object key
+        self.mock_kafka_producer.produce_document_processed_event.assert_called_once()
+        produced_event = self.mock_kafka_producer.produce_document_processed_event.call_args[0][0]
+        self.assertIsInstance(produced_event, DocumentProcessedEvent)
+        self.assertEqual(produced_event.status, "FAILED")
+        self.assertIn("original_object_key is required", produced_event.error_message)
 
 if __name__ == '__main__':
     unittest.main()

--- a/ms_document_process/tests/test_kafka_integration.py
+++ b/ms_document_process/tests/test_kafka_integration.py
@@ -74,10 +74,16 @@ class TestKafkaIntegration(unittest.TestCase):
 
     def test_end_to_end_processes_message_and_emits_processed_event(self):
         with kafka_topics(self.admin, [self.source_topic, self.processed_topic]):
+            content_source_id = uuid4()
+            space_id = uuid4()
+            owner_id = uuid4()
+            filename = "test-document.pdf"
+            
             event = DocumentUploadedEvent(
-                content_source_id=uuid4(),
+                content_source_id=content_source_id,
                 original_blob_hash='original_hash',
-                space_id=uuid4(),
+                space_id=space_id,
+                original_object_key=f"{owner_id}/spaces/{space_id}/content/{content_source_id}/{filename}"
             )
 
             # Patch conversion to avoid external PDF tooling

--- a/ms_knowledge/api/proto/v1/knowledge.pb.go
+++ b/ms_knowledge/api/proto/v1/knowledge.pb.go
@@ -1380,9 +1380,8 @@ func (x *CreateUploadURLResponse) GetContentSource() *ContentSource {
 
 type ConfirmUploadRequest struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
-	ContentSourceId string                 `protobuf:"bytes,1,opt,name=content_source_id,json=contentSourceId,proto3" json:"content_source_id,omitempty"`                      // required
-	ObjectKind      DownloadObjectKind     `protobuf:"varint,2,opt,name=object_kind,json=objectKind,proto3,enum=knowledge.v1.DownloadObjectKind" json:"object_kind,omitempty"` // required
-	BlobHash        string                 `protobuf:"bytes,3,opt,name=blob_hash,json=blobHash,proto3" json:"blob_hash,omitempty"`                                             // required
+	ContentSourceId string                 `protobuf:"bytes,1,opt,name=content_source_id,json=contentSourceId,proto3" json:"content_source_id,omitempty"` // required
+	BlobHash        string                 `protobuf:"bytes,3,opt,name=blob_hash,json=blobHash,proto3" json:"blob_hash,omitempty"`                        // required
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -1422,13 +1421,6 @@ func (x *ConfirmUploadRequest) GetContentSourceId() string {
 		return x.ContentSourceId
 	}
 	return ""
-}
-
-func (x *ConfirmUploadRequest) GetObjectKind() DownloadObjectKind {
-	if x != nil {
-		return x.ObjectKind
-	}
-	return DownloadObjectKind_DOWNLOAD_OBJECT_KIND_UNSPECIFIED
 }
 
 func (x *ConfirmUploadRequest) GetBlobHash() string {
@@ -2612,11 +2604,9 @@ const file_api_proto_v1_knowledge_proto_rawDesc = "" +
 	"\n" +
 	"expires_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x12B\n" +
 	"\x0econtent_source\x18\n" +
-	" \x01(\v2\x1b.knowledge.v1.ContentSourceR\rcontentSource\"\xa2\x01\n" +
+	" \x01(\v2\x1b.knowledge.v1.ContentSourceR\rcontentSource\"_\n" +
 	"\x14ConfirmUploadRequest\x12*\n" +
-	"\x11content_source_id\x18\x01 \x01(\tR\x0fcontentSourceId\x12A\n" +
-	"\vobject_kind\x18\x02 \x01(\x0e2 .knowledge.v1.DownloadObjectKindR\n" +
-	"objectKind\x12\x1b\n" +
+	"\x11content_source_id\x18\x01 \x01(\tR\x0fcontentSourceId\x12\x1b\n" +
 	"\tblob_hash\x18\x03 \x01(\tR\bblobHash\")\n" +
 	"\x17GetContentSourceRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"\x99\x01\n" +
@@ -2834,75 +2824,74 @@ var file_api_proto_v1_knowledge_proto_depIdxs = []int32{
 	3,  // 23: knowledge.v1.CreateUploadURLRequest.object_kind:type_name -> knowledge.v1.DownloadObjectKind
 	40, // 24: knowledge.v1.CreateUploadURLResponse.expires_at:type_name -> google.protobuf.Timestamp
 	7,  // 25: knowledge.v1.CreateUploadURLResponse.content_source:type_name -> knowledge.v1.ContentSource
-	3,  // 26: knowledge.v1.ConfirmUploadRequest.object_kind:type_name -> knowledge.v1.DownloadObjectKind
-	0,  // 27: knowledge.v1.ListContentSourcesRequest.status:type_name -> knowledge.v1.ContentStatus
-	4,  // 28: knowledge.v1.ListContentSourcesRequest.page:type_name -> knowledge.v1.Pagination
-	7,  // 29: knowledge.v1.ListContentSourcesResponse.items:type_name -> knowledge.v1.ContentSource
-	7,  // 30: knowledge.v1.UpdateContentSourceRequest.content:type_name -> knowledge.v1.ContentSource
-	41, // 31: knowledge.v1.UpdateContentSourceRequest.update_mask:type_name -> google.protobuf.FieldMask
-	0,  // 32: knowledge.v1.UpdateContentSourceStatusRequest.status:type_name -> knowledge.v1.ContentStatus
-	3,  // 33: knowledge.v1.GenerateDownloadURLRequest.object_kind:type_name -> knowledge.v1.DownloadObjectKind
-	40, // 34: knowledge.v1.GenerateDownloadURLResponse.expires_at:type_name -> google.protobuf.Timestamp
-	1,  // 35: knowledge.v1.CreateKnowledgeLinkRequest.relation_type:type_name -> knowledge.v1.RelationType
-	2,  // 36: knowledge.v1.ListKnowledgeLinksRequest.direction:type_name -> knowledge.v1.LinkDirection
-	1,  // 37: knowledge.v1.ListKnowledgeLinksRequest.relation_type:type_name -> knowledge.v1.RelationType
-	4,  // 38: knowledge.v1.ListKnowledgeLinksRequest.page:type_name -> knowledge.v1.Pagination
-	10, // 39: knowledge.v1.ListKnowledgeLinksResponse.items:type_name -> knowledge.v1.EnrichedKnowledgeLink
-	1,  // 40: knowledge.v1.ListAllSpaceLinksRequest.relation_type:type_name -> knowledge.v1.RelationType
-	4,  // 41: knowledge.v1.ListAllSpaceLinksRequest.page:type_name -> knowledge.v1.Pagination
-	8,  // 42: knowledge.v1.ListAllSpaceLinksResponse.items:type_name -> knowledge.v1.KnowledgeLink
-	8,  // 43: knowledge.v1.UpdateKnowledgeLinkRequest.link:type_name -> knowledge.v1.KnowledgeLink
-	41, // 44: knowledge.v1.UpdateKnowledgeLinkRequest.update_mask:type_name -> google.protobuf.FieldMask
-	4,  // 45: knowledge.v1.GetBacklinksRequest.page:type_name -> knowledge.v1.Pagination
-	8,  // 46: knowledge.v1.GetBacklinksResponse.items:type_name -> knowledge.v1.KnowledgeLink
-	39, // 47: knowledge.v1.HealthStatus.components:type_name -> knowledge.v1.HealthStatus.ComponentsEntry
-	11, // 48: knowledge.v1.KnowledgeService.CreateSpace:input_type -> knowledge.v1.CreateSpaceRequest
-	12, // 49: knowledge.v1.KnowledgeService.GetSpace:input_type -> knowledge.v1.GetSpaceRequest
-	13, // 50: knowledge.v1.KnowledgeService.ListSpaces:input_type -> knowledge.v1.ListSpacesRequest
-	15, // 51: knowledge.v1.KnowledgeService.UpdateSpace:input_type -> knowledge.v1.UpdateSpaceRequest
-	16, // 52: knowledge.v1.KnowledgeService.DeleteSpace:input_type -> knowledge.v1.DeleteSpaceRequest
-	17, // 53: knowledge.v1.KnowledgeService.CreateUploadURL:input_type -> knowledge.v1.CreateUploadURLRequest
-	19, // 54: knowledge.v1.KnowledgeService.ConfirmUpload:input_type -> knowledge.v1.ConfirmUploadRequest
-	20, // 55: knowledge.v1.KnowledgeService.GetContentSource:input_type -> knowledge.v1.GetContentSourceRequest
-	21, // 56: knowledge.v1.KnowledgeService.ListContentSources:input_type -> knowledge.v1.ListContentSourcesRequest
-	23, // 57: knowledge.v1.KnowledgeService.UpdateContentSource:input_type -> knowledge.v1.UpdateContentSourceRequest
-	24, // 58: knowledge.v1.KnowledgeService.UpdateContentSourceStatus:input_type -> knowledge.v1.UpdateContentSourceStatusRequest
-	25, // 59: knowledge.v1.KnowledgeService.DeleteContentSource:input_type -> knowledge.v1.DeleteContentSourceRequest
-	26, // 60: knowledge.v1.KnowledgeService.GenerateDownloadURL:input_type -> knowledge.v1.GenerateDownloadURLRequest
-	28, // 61: knowledge.v1.KnowledgeService.CreateKnowledgeLink:input_type -> knowledge.v1.CreateKnowledgeLinkRequest
-	29, // 62: knowledge.v1.KnowledgeService.GetKnowledgeLink:input_type -> knowledge.v1.GetKnowledgeLinkRequest
-	30, // 63: knowledge.v1.KnowledgeService.ListKnowledgeLinks:input_type -> knowledge.v1.ListKnowledgeLinksRequest
-	32, // 64: knowledge.v1.KnowledgeService.ListAllSpaceLinks:input_type -> knowledge.v1.ListAllSpaceLinksRequest
-	34, // 65: knowledge.v1.KnowledgeService.UpdateKnowledgeLink:input_type -> knowledge.v1.UpdateKnowledgeLinkRequest
-	35, // 66: knowledge.v1.KnowledgeService.DeleteKnowledgeLink:input_type -> knowledge.v1.DeleteKnowledgeLinkRequest
-	36, // 67: knowledge.v1.KnowledgeService.GetBacklinks:input_type -> knowledge.v1.GetBacklinksRequest
-	42, // 68: knowledge.v1.KnowledgeService.Healthz:input_type -> google.protobuf.Empty
-	6,  // 69: knowledge.v1.KnowledgeService.CreateSpace:output_type -> knowledge.v1.Space
-	6,  // 70: knowledge.v1.KnowledgeService.GetSpace:output_type -> knowledge.v1.Space
-	14, // 71: knowledge.v1.KnowledgeService.ListSpaces:output_type -> knowledge.v1.ListSpacesResponse
-	6,  // 72: knowledge.v1.KnowledgeService.UpdateSpace:output_type -> knowledge.v1.Space
-	42, // 73: knowledge.v1.KnowledgeService.DeleteSpace:output_type -> google.protobuf.Empty
-	18, // 74: knowledge.v1.KnowledgeService.CreateUploadURL:output_type -> knowledge.v1.CreateUploadURLResponse
-	7,  // 75: knowledge.v1.KnowledgeService.ConfirmUpload:output_type -> knowledge.v1.ContentSource
-	7,  // 76: knowledge.v1.KnowledgeService.GetContentSource:output_type -> knowledge.v1.ContentSource
-	22, // 77: knowledge.v1.KnowledgeService.ListContentSources:output_type -> knowledge.v1.ListContentSourcesResponse
-	7,  // 78: knowledge.v1.KnowledgeService.UpdateContentSource:output_type -> knowledge.v1.ContentSource
-	7,  // 79: knowledge.v1.KnowledgeService.UpdateContentSourceStatus:output_type -> knowledge.v1.ContentSource
-	42, // 80: knowledge.v1.KnowledgeService.DeleteContentSource:output_type -> google.protobuf.Empty
-	27, // 81: knowledge.v1.KnowledgeService.GenerateDownloadURL:output_type -> knowledge.v1.GenerateDownloadURLResponse
-	8,  // 82: knowledge.v1.KnowledgeService.CreateKnowledgeLink:output_type -> knowledge.v1.KnowledgeLink
-	10, // 83: knowledge.v1.KnowledgeService.GetKnowledgeLink:output_type -> knowledge.v1.EnrichedKnowledgeLink
-	31, // 84: knowledge.v1.KnowledgeService.ListKnowledgeLinks:output_type -> knowledge.v1.ListKnowledgeLinksResponse
-	33, // 85: knowledge.v1.KnowledgeService.ListAllSpaceLinks:output_type -> knowledge.v1.ListAllSpaceLinksResponse
-	8,  // 86: knowledge.v1.KnowledgeService.UpdateKnowledgeLink:output_type -> knowledge.v1.KnowledgeLink
-	42, // 87: knowledge.v1.KnowledgeService.DeleteKnowledgeLink:output_type -> google.protobuf.Empty
-	37, // 88: knowledge.v1.KnowledgeService.GetBacklinks:output_type -> knowledge.v1.GetBacklinksResponse
-	38, // 89: knowledge.v1.KnowledgeService.Healthz:output_type -> knowledge.v1.HealthStatus
-	69, // [69:90] is the sub-list for method output_type
-	48, // [48:69] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	0,  // 26: knowledge.v1.ListContentSourcesRequest.status:type_name -> knowledge.v1.ContentStatus
+	4,  // 27: knowledge.v1.ListContentSourcesRequest.page:type_name -> knowledge.v1.Pagination
+	7,  // 28: knowledge.v1.ListContentSourcesResponse.items:type_name -> knowledge.v1.ContentSource
+	7,  // 29: knowledge.v1.UpdateContentSourceRequest.content:type_name -> knowledge.v1.ContentSource
+	41, // 30: knowledge.v1.UpdateContentSourceRequest.update_mask:type_name -> google.protobuf.FieldMask
+	0,  // 31: knowledge.v1.UpdateContentSourceStatusRequest.status:type_name -> knowledge.v1.ContentStatus
+	3,  // 32: knowledge.v1.GenerateDownloadURLRequest.object_kind:type_name -> knowledge.v1.DownloadObjectKind
+	40, // 33: knowledge.v1.GenerateDownloadURLResponse.expires_at:type_name -> google.protobuf.Timestamp
+	1,  // 34: knowledge.v1.CreateKnowledgeLinkRequest.relation_type:type_name -> knowledge.v1.RelationType
+	2,  // 35: knowledge.v1.ListKnowledgeLinksRequest.direction:type_name -> knowledge.v1.LinkDirection
+	1,  // 36: knowledge.v1.ListKnowledgeLinksRequest.relation_type:type_name -> knowledge.v1.RelationType
+	4,  // 37: knowledge.v1.ListKnowledgeLinksRequest.page:type_name -> knowledge.v1.Pagination
+	10, // 38: knowledge.v1.ListKnowledgeLinksResponse.items:type_name -> knowledge.v1.EnrichedKnowledgeLink
+	1,  // 39: knowledge.v1.ListAllSpaceLinksRequest.relation_type:type_name -> knowledge.v1.RelationType
+	4,  // 40: knowledge.v1.ListAllSpaceLinksRequest.page:type_name -> knowledge.v1.Pagination
+	8,  // 41: knowledge.v1.ListAllSpaceLinksResponse.items:type_name -> knowledge.v1.KnowledgeLink
+	8,  // 42: knowledge.v1.UpdateKnowledgeLinkRequest.link:type_name -> knowledge.v1.KnowledgeLink
+	41, // 43: knowledge.v1.UpdateKnowledgeLinkRequest.update_mask:type_name -> google.protobuf.FieldMask
+	4,  // 44: knowledge.v1.GetBacklinksRequest.page:type_name -> knowledge.v1.Pagination
+	8,  // 45: knowledge.v1.GetBacklinksResponse.items:type_name -> knowledge.v1.KnowledgeLink
+	39, // 46: knowledge.v1.HealthStatus.components:type_name -> knowledge.v1.HealthStatus.ComponentsEntry
+	11, // 47: knowledge.v1.KnowledgeService.CreateSpace:input_type -> knowledge.v1.CreateSpaceRequest
+	12, // 48: knowledge.v1.KnowledgeService.GetSpace:input_type -> knowledge.v1.GetSpaceRequest
+	13, // 49: knowledge.v1.KnowledgeService.ListSpaces:input_type -> knowledge.v1.ListSpacesRequest
+	15, // 50: knowledge.v1.KnowledgeService.UpdateSpace:input_type -> knowledge.v1.UpdateSpaceRequest
+	16, // 51: knowledge.v1.KnowledgeService.DeleteSpace:input_type -> knowledge.v1.DeleteSpaceRequest
+	17, // 52: knowledge.v1.KnowledgeService.CreateUploadURL:input_type -> knowledge.v1.CreateUploadURLRequest
+	19, // 53: knowledge.v1.KnowledgeService.ConfirmUpload:input_type -> knowledge.v1.ConfirmUploadRequest
+	20, // 54: knowledge.v1.KnowledgeService.GetContentSource:input_type -> knowledge.v1.GetContentSourceRequest
+	21, // 55: knowledge.v1.KnowledgeService.ListContentSources:input_type -> knowledge.v1.ListContentSourcesRequest
+	23, // 56: knowledge.v1.KnowledgeService.UpdateContentSource:input_type -> knowledge.v1.UpdateContentSourceRequest
+	24, // 57: knowledge.v1.KnowledgeService.UpdateContentSourceStatus:input_type -> knowledge.v1.UpdateContentSourceStatusRequest
+	25, // 58: knowledge.v1.KnowledgeService.DeleteContentSource:input_type -> knowledge.v1.DeleteContentSourceRequest
+	26, // 59: knowledge.v1.KnowledgeService.GenerateDownloadURL:input_type -> knowledge.v1.GenerateDownloadURLRequest
+	28, // 60: knowledge.v1.KnowledgeService.CreateKnowledgeLink:input_type -> knowledge.v1.CreateKnowledgeLinkRequest
+	29, // 61: knowledge.v1.KnowledgeService.GetKnowledgeLink:input_type -> knowledge.v1.GetKnowledgeLinkRequest
+	30, // 62: knowledge.v1.KnowledgeService.ListKnowledgeLinks:input_type -> knowledge.v1.ListKnowledgeLinksRequest
+	32, // 63: knowledge.v1.KnowledgeService.ListAllSpaceLinks:input_type -> knowledge.v1.ListAllSpaceLinksRequest
+	34, // 64: knowledge.v1.KnowledgeService.UpdateKnowledgeLink:input_type -> knowledge.v1.UpdateKnowledgeLinkRequest
+	35, // 65: knowledge.v1.KnowledgeService.DeleteKnowledgeLink:input_type -> knowledge.v1.DeleteKnowledgeLinkRequest
+	36, // 66: knowledge.v1.KnowledgeService.GetBacklinks:input_type -> knowledge.v1.GetBacklinksRequest
+	42, // 67: knowledge.v1.KnowledgeService.Healthz:input_type -> google.protobuf.Empty
+	6,  // 68: knowledge.v1.KnowledgeService.CreateSpace:output_type -> knowledge.v1.Space
+	6,  // 69: knowledge.v1.KnowledgeService.GetSpace:output_type -> knowledge.v1.Space
+	14, // 70: knowledge.v1.KnowledgeService.ListSpaces:output_type -> knowledge.v1.ListSpacesResponse
+	6,  // 71: knowledge.v1.KnowledgeService.UpdateSpace:output_type -> knowledge.v1.Space
+	42, // 72: knowledge.v1.KnowledgeService.DeleteSpace:output_type -> google.protobuf.Empty
+	18, // 73: knowledge.v1.KnowledgeService.CreateUploadURL:output_type -> knowledge.v1.CreateUploadURLResponse
+	7,  // 74: knowledge.v1.KnowledgeService.ConfirmUpload:output_type -> knowledge.v1.ContentSource
+	7,  // 75: knowledge.v1.KnowledgeService.GetContentSource:output_type -> knowledge.v1.ContentSource
+	22, // 76: knowledge.v1.KnowledgeService.ListContentSources:output_type -> knowledge.v1.ListContentSourcesResponse
+	7,  // 77: knowledge.v1.KnowledgeService.UpdateContentSource:output_type -> knowledge.v1.ContentSource
+	7,  // 78: knowledge.v1.KnowledgeService.UpdateContentSourceStatus:output_type -> knowledge.v1.ContentSource
+	42, // 79: knowledge.v1.KnowledgeService.DeleteContentSource:output_type -> google.protobuf.Empty
+	27, // 80: knowledge.v1.KnowledgeService.GenerateDownloadURL:output_type -> knowledge.v1.GenerateDownloadURLResponse
+	8,  // 81: knowledge.v1.KnowledgeService.CreateKnowledgeLink:output_type -> knowledge.v1.KnowledgeLink
+	10, // 82: knowledge.v1.KnowledgeService.GetKnowledgeLink:output_type -> knowledge.v1.EnrichedKnowledgeLink
+	31, // 83: knowledge.v1.KnowledgeService.ListKnowledgeLinks:output_type -> knowledge.v1.ListKnowledgeLinksResponse
+	33, // 84: knowledge.v1.KnowledgeService.ListAllSpaceLinks:output_type -> knowledge.v1.ListAllSpaceLinksResponse
+	8,  // 85: knowledge.v1.KnowledgeService.UpdateKnowledgeLink:output_type -> knowledge.v1.KnowledgeLink
+	42, // 86: knowledge.v1.KnowledgeService.DeleteKnowledgeLink:output_type -> google.protobuf.Empty
+	37, // 87: knowledge.v1.KnowledgeService.GetBacklinks:output_type -> knowledge.v1.GetBacklinksResponse
+	38, // 88: knowledge.v1.KnowledgeService.Healthz:output_type -> knowledge.v1.HealthStatus
+	68, // [68:89] is the sub-list for method output_type
+	47, // [47:68] is the sub-list for method input_type
+	47, // [47:47] is the sub-list for extension type_name
+	47, // [47:47] is the sub-list for extension extendee
+	0,  // [0:47] is the sub-list for field type_name
 }
 
 func init() { file_api_proto_v1_knowledge_proto_init() }

--- a/ms_knowledge/api/proto/v1/knowledge.proto
+++ b/ms_knowledge/api/proto/v1/knowledge.proto
@@ -206,7 +206,6 @@ message CreateUploadURLResponse {
 
 message ConfirmUploadRequest {
   string content_source_id = 1;      // required
-  DownloadObjectKind object_kind = 2; // required
   string blob_hash = 3;              // required
 }
 

--- a/ms_knowledge/cmd/main.go
+++ b/ms_knowledge/cmd/main.go
@@ -196,14 +196,14 @@ func main() {
 	slog.Info("Shutting down server...")
 	cancel() // Cancel context for consumer
 	srv.GracefulStop()
-	
+
 	// Close User service connection
 	if userConn != nil {
 		if err := userConn.Close(); err != nil {
 			slog.Warn("Failed to close User service connection", "error", err)
 		}
 	}
-	
+
 	slog.Info("Server stopped")
 }
 
@@ -238,6 +238,13 @@ func (h *processedHandler) HandleDocumentProcessed(ctx context.Context, event ev
 	if event.ProcessedBlobHash != nil {
 		processedHash = *event.ProcessedBlobHash
 	}
-	_, err = h.svc.UpdateContentSourceStatus(ctx, event.ContentSourceID, status, processedHash, event.ErrorMessage)
+
+	ownerID, err := h.svc.GetContentOwner(ctx, event.ContentSourceID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve content owner: %w", err)
+	}
+	ctxWithOwner := context.WithValue(ctx, domain.OwnerIDKey, ownerID.String())
+
+	_, err = h.svc.UpdateContentSourceStatus(ctxWithOwner, event.ContentSourceID, status, processedHash, event.ErrorMessage)
 	return err
 }

--- a/ms_knowledge/internal/server/grpc.go
+++ b/ms_knowledge/internal/server/grpc.go
@@ -146,18 +146,7 @@ func (s *GRPCServer) CreateUploadURL(ctx context.Context, req *knowledgev1.Creat
 		return nil, status.Errorf(codes.InvalidArgument, "invalid space id: %v", err)
 	}
 
-	// Map object_kind enum to kind string
-	var kind string
-	switch req.ObjectKind {
-	case knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL:
-		kind = "source"
-	case knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_PROCESSED:
-		kind = "processed"
-	default:
-		return nil, status.Errorf(codes.InvalidArgument, "object_kind is required")
-	}
-
-	content, uploadURL, objectKey, expiresAt, err := s.contentService.CreateUploadURLWithKind(ctx, spaceID, req.Filename, req.MimeType, req.SizeBytes, req.Title, kind)
+	content, uploadURL, objectKey, expiresAt, err := s.contentService.CreateUploadURL(ctx, spaceID, req.Filename, req.MimeType, req.SizeBytes, req.Title, req.ObjectKind)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create upload URL: %v", err)
 	}
@@ -176,21 +165,12 @@ func (s *GRPCServer) ConfirmUpload(ctx context.Context, req *knowledgev1.Confirm
 		return nil, status.Errorf(codes.InvalidArgument, "invalid content source id: %v", err)
 	}
 
-	// Validate kind and map
-	var kind string
-	switch req.ObjectKind {
-	case knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL:
-		kind = "source"
-	case knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_PROCESSED:
-		kind = "processed"
-	default:
-		return nil, status.Errorf(codes.InvalidArgument, "object_kind is required")
-	}
 	if strings.TrimSpace(req.BlobHash) == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "blob_hash is required")
 	}
 
-	content, err := s.contentService.ConfirmUploadWithKind(ctx, contentID, kind, req.BlobHash)
+	// Use the standard ConfirmUpload method
+	content, err := s.contentService.ConfirmUpload(ctx, contentID, req.BlobHash)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to confirm upload: %v", err)
 	}
@@ -331,17 +311,6 @@ func (s *GRPCServer) GenerateDownloadURL(ctx context.Context, req *knowledgev1.G
 		return nil, status.Errorf(codes.InvalidArgument, "invalid content source id: %v", err)
 	}
 
-	// Validate object_kind early
-	var kind string
-	switch req.ObjectKind {
-	case knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL:
-		kind = "source"
-	case knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_PROCESSED:
-		kind = "processed"
-	default:
-		return nil, status.Errorf(codes.InvalidArgument, "object_kind is required")
-	}
-
 	// TTL bounds
 	ttl := 15 * time.Minute
 	if req.ExpiresSeconds > 0 {
@@ -354,18 +323,20 @@ func (s *GRPCServer) GenerateDownloadURL(ctx context.Context, req *knowledgev1.G
 		ttl = time.Duration(req.ExpiresSeconds) * time.Second
 	}
 
+	// Use the simplified method that accepts kind directly
+	url, expiresAt, err := s.contentService.GenerateDownloadURL(ctx, contentID, req.ObjectKind, ttl)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to generate download URL: %v", err)
+	}
+
 	// Fetch content to compute object key; RLS is enforced in service layer
 	content, err := s.contentService.GetContentSource(ctx, contentID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get content source: %v", err)
 	}
 
-	url, expiresAt, err := s.contentService.GenerateDownloadURLWithKind(ctx, contentID, ttl, kind)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to generate download URL: %v", err)
-	}
-
-	objectKey := "spaces/" + content.SpaceID.String() + "/content/" + content.ID.String() + "/" + content.Source
+	// Generate object key using consistent path format
+	objectKey := content.OwnerID.String() + "/spaces/" + content.SpaceID.String() + "/content/" + content.ID.String() + "/" + content.Source
 
 	return &knowledgev1.GenerateDownloadURLResponse{
 		Url:       url,

--- a/ms_knowledge/internal/service/content_service.go
+++ b/ms_knowledge/internal/service/content_service.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	knowledgev1 "demo/ms_knowledge/api/proto/v1"
 	"demo/ms_knowledge/internal/config"
 	"demo/ms_knowledge/internal/domain"
 	"demo/ms_knowledge/internal/events"
@@ -59,35 +60,36 @@ func (s *ContentService) scopeContentFilterToOwner(ctx context.Context, filter d
 	return filter, nil
 }
 
-// resolveBucket returns the bucket name for a given kind ("source" or "processed").
-func (s *ContentService) resolveBucket(kind string) (string, error) {
-	switch strings.ToLower(strings.TrimSpace(kind)) {
-	case "source", "original":
-		if s.cfg == nil || s.cfg.R2.BucketSourceName == "" {
+// buildObjectKey constructs the R2 object key including the owner prefix and space/content path
+func buildObjectKey(ownerID, spaceID, contentID uuid.UUID, filename string) string {
+	// <userId>/spaces/<spaceId>/content/<contentSourceId>/<fileName>
+	return ownerID.String() + "/spaces/" + spaceID.String() + "/content/" + contentID.String() + "/" + strings.TrimSpace(filename)
+}
+
+// getBucketFromObjectKind returns the appropriate bucket name based on the object kind
+func (s *ContentService) getBucketFromObjectKind(kind knowledgev1.DownloadObjectKind) (string, error) {
+	if s.cfg == nil {
+		return "", fmt.Errorf("configuration not available")
+	}
+
+	switch kind {
+	case knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL:
+		if strings.TrimSpace(s.cfg.R2.BucketSourceName) == "" {
 			return "", fmt.Errorf("R2 source bucket not configured")
 		}
 		return s.cfg.R2.BucketSourceName, nil
-	case "processed":
-		if s.cfg == nil || s.cfg.R2.BucketProcessedName == "" {
+	case knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_PROCESSED:
+		if strings.TrimSpace(s.cfg.R2.BucketProcessedName) == "" {
 			return "", fmt.Errorf("R2 processed bucket not configured")
 		}
 		return s.cfg.R2.BucketProcessedName, nil
 	default:
-		return "", fmt.Errorf("invalid kind: %s", kind)
+		return "", fmt.Errorf("unsupported object kind: %v", kind)
 	}
 }
 
-func (s *ContentService) CreateUploadURL(ctx context.Context, spaceID uuid.UUID, filename, mimeType string, sizeBytes int64, title string) (*domain.ContentSource, string, error) {
-	content, uploadURL, _, _, err := s.CreateUploadURLWithKind(ctx, spaceID, filename, mimeType, sizeBytes, title, "source")
-	if err != nil {
-		return nil, "", err
-	}
-	return content, uploadURL, nil
-}
-
-// CreateUploadURLWithKind issues a presigned upload URL for the requested kind ("source" or "processed").
-// Returns content, uploadURL, objectKey, expiresAt.
-func (s *ContentService) CreateUploadURLWithKind(ctx context.Context, spaceID uuid.UUID, filename, mimeType string, sizeBytes int64, title, kind string) (*domain.ContentSource, string, string, time.Time, error) {
+// CreateUploadURL issues a presigned upload URL for content source.
+func (s *ContentService) CreateUploadURL(ctx context.Context, spaceID uuid.UUID, filename, mimeType string, sizeBytes int64, title string, kind knowledgev1.DownloadObjectKind) (*domain.ContentSource, string, string, time.Time, error) {
 	// Validate inputs
 	if spaceID == uuid.Nil {
 		return nil, "", "", time.Time{}, fmt.Errorf("space_id is required")
@@ -97,9 +99,6 @@ func (s *ContentService) CreateUploadURLWithKind(ctx context.Context, spaceID uu
 	}
 	if strings.TrimSpace(mimeType) == "" {
 		return nil, "", "", time.Time{}, fmt.Errorf("mime_type is required")
-	}
-	if strings.TrimSpace(kind) == "" {
-		return nil, "", "", time.Time{}, fmt.Errorf("kind is required")
 	}
 
 	// Check if space exists
@@ -140,10 +139,10 @@ func (s *ContentService) CreateUploadURLWithKind(ctx context.Context, spaceID uu
 	}
 
 	// Generate object key based on persisted content ID
-	objectKey := fmt.Sprintf("spaces/%s/content/%s/%s", spaceID.String(), content.ID.String(), filename)
+	objectKey := buildObjectKey(ownerUUID, spaceID, content.ID, filename)
 
-	// Resolve bucket for requested kind
-	bucket, err := s.resolveBucket(kind)
+	// Get appropriate bucket based on object kind
+	bucket, err := s.getBucketFromObjectKind(kind)
 	if err != nil {
 		return nil, "", "", time.Time{}, err
 	}
@@ -158,13 +157,8 @@ func (s *ContentService) CreateUploadURLWithKind(ctx context.Context, spaceID uu
 	return content, uploadURL, objectKey, time.Now().Add(expires), nil
 }
 
-// ConfirmUpload remains for backward-compatibility and updates original blob hash.
-func (s *ContentService) ConfirmUpload(ctx context.Context, contentID uuid.UUID, originalBlobHash string) (*domain.ContentSource, error) {
-	return s.ConfirmUploadWithKind(ctx, contentID, "source", originalBlobHash)
-}
-
-// ConfirmUploadWithKind updates only the corresponding hash field based on kind.
-func (s *ContentService) ConfirmUploadWithKind(ctx context.Context, contentID uuid.UUID, kind string, blobHash string) (*domain.ContentSource, error) {
+// ConfirmUpload updates the original blob hash and marks the content as uploaded.
+func (s *ContentService) ConfirmUpload(ctx context.Context, contentID uuid.UUID, blobHash string) (*domain.ContentSource, error) {
 	// Get content source
 	content, err := s.contentRepo.GetByID(ctx, contentID)
 	if err != nil {
@@ -176,25 +170,18 @@ func (s *ContentService) ConfirmUploadWithKind(ctx context.Context, contentID uu
 		return nil, err
 	}
 
-	// Update only the targeted field
-	switch strings.ToLower(strings.TrimSpace(kind)) {
-	case "source", "original":
-		content.Status = domain.ContentStatusUploaded
-		content.OriginalBlobHash = blobHash
-	case "processed":
-		content.ProcessedBlobHash = &blobHash
-	default:
-		return nil, fmt.Errorf("invalid kind: %s", kind)
-	}
+	// Update status and hash for the original upload
+	content.Status = domain.ContentStatusUploaded
+	content.OriginalBlobHash = blobHash
 
 	err = s.contentRepo.Update(ctx, content)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update content source: %w", err)
 	}
 
-	// Emit document.uploaded event only for ORIGINAL confirms
-	if s.producer != nil && (strings.ToLower(strings.TrimSpace(kind)) == "source" || strings.ToLower(strings.TrimSpace(kind)) == "original") {
-		objectKey := fmt.Sprintf("spaces/%s/content/%s/%s", content.SpaceID.String(), content.ID.String(), strings.TrimSpace(content.Source))
+	// Emit document.uploaded event
+	if s.producer != nil {
+		objectKey := buildObjectKey(content.OwnerID, content.SpaceID, content.ID, strings.TrimSpace(content.Source))
 		evt := events.DocumentUploadedEvent{
 			ContentSourceID:   content.ID,
 			OriginalBlobHash:  blobHash,
@@ -257,7 +244,6 @@ func (s *ContentService) UpdateContentSourceStatus(ctx context.Context, id uuid.
 		return nil, fmt.Errorf("failed to get content source: %w", err)
 	}
 
-	// Note: this is typically called by internal pipelines; if exposed to users,
 	// enforce RLS here. For now, ensure only the owner can update status.
 	if err := EnforceOwner(ctx, content.OwnerID); err != nil {
 		return nil, err
@@ -272,7 +258,6 @@ func (s *ContentService) UpdateContentSourceStatus(ctx context.Context, id uuid.
 	// Validate status transition
 	if err := content.Status.ValidateTransition(status); err != nil {
 		s.logger.Printf("Invalid status transition for content source %s: %v", id, err)
-		// Log the error but still allow the transition for now to avoid breaking existing workflows
 		// In production, you might want to return this error instead
 	}
 
@@ -281,9 +266,6 @@ func (s *ContentService) UpdateContentSourceStatus(ctx context.Context, id uuid.
 	if err != nil {
 		return nil, fmt.Errorf("failed to update content source status: %w", err)
 	}
-
-	// Content nodes are automatically created in Neo4j when content is created in the repository
-	// No additional graph operations needed here
 
 	// Get updated content source
 	content, err = s.contentRepo.GetByID(ctx, id)
@@ -370,13 +352,8 @@ func (s *ContentService) ValidateSpaceContentIntegrity(ctx context.Context) (*Sp
 	return report, nil
 }
 
-// GenerateDownloadURL returns a short-lived pre-signed URL to download the original uploaded blob.
-func (s *ContentService) GenerateDownloadURL(ctx context.Context, contentID uuid.UUID, expires time.Duration) (string, time.Time, error) {
-	return s.GenerateDownloadURLWithKind(ctx, contentID, expires, "source")
-}
-
-// GenerateDownloadURLWithKind generates a presigned download URL for the requested kind.
-func (s *ContentService) GenerateDownloadURLWithKind(ctx context.Context, contentID uuid.UUID, expires time.Duration, kind string) (string, time.Time, error) {
+// GenerateDownloadURL returns a short-lived pre-signed URL to download the uploaded blob.
+func (s *ContentService) GenerateDownloadURL(ctx context.Context, contentID uuid.UUID, kind knowledgev1.DownloadObjectKind, expires time.Duration) (string, time.Time, error) {
 	if contentID == uuid.Nil {
 		return "", time.Time{}, fmt.Errorf("content_id is required")
 	}
@@ -391,7 +368,8 @@ func (s *ContentService) GenerateDownloadURLWithKind(ctx context.Context, conten
 		return "", time.Time{}, err
 	}
 
-	bucket, err := s.resolveBucket(kind)
+	// Get appropriate bucket based on download kind
+	bucket, err := s.getBucketFromObjectKind(kind)
 	if err != nil {
 		return "", time.Time{}, err
 	}
@@ -400,7 +378,8 @@ func (s *ContentService) GenerateDownloadURLWithKind(ctx context.Context, conten
 		expires = 15 * time.Minute
 	}
 
-	objectKey := fmt.Sprintf("spaces/%s/content/%s/%s", content.SpaceID.String(), content.ID.String(), content.Source)
+	filename := content.Source
+	objectKey := buildObjectKey(content.OwnerID, content.SpaceID, content.ID, filename)
 
 	url, err := s.storage.GeneratePresignedDownloadURL(bucket, objectKey, expires)
 	if err != nil {
@@ -422,16 +401,22 @@ func (s *ContentService) DeleteContentSource(ctx context.Context, id uuid.UUID) 
 		return err
 	}
 
-	bucket, err := s.resolveBucket("source")
-	if err != nil {
-		return fmt.Errorf("failed to resolve source bucket: %w", err)
+	filename := strings.TrimSpace(content.Source)
+	objectKey := buildObjectKey(content.OwnerID, content.SpaceID, content.ID, filename)
+
+	// Delete from both source and processed buckets (best effort)
+	// Try source bucket
+	if s.cfg != nil && strings.TrimSpace(s.cfg.R2.BucketSourceName) != "" {
+		if err := s.storage.DeleteObject(s.cfg.R2.BucketSourceName, objectKey); err != nil {
+			s.logger.Printf("WARN: failed to delete R2 object from source bucket (bucket=%s key=%s): %v", s.cfg.R2.BucketSourceName, objectKey, err)
+		}
 	}
 
-	filename := strings.TrimSpace(content.Source)
-	objectKey := fmt.Sprintf("spaces/%s/content/%s/%s", content.SpaceID.String(), content.ID.String(), filename)
-
-	if err := s.storage.DeleteObject(bucket, objectKey); err != nil {
-		s.logger.Printf("WARN: failed to delete R2 object (bucket=%s key=%s): %v", bucket, objectKey, err)
+	// Try processed bucket
+	if s.cfg != nil && strings.TrimSpace(s.cfg.R2.BucketProcessedName) != "" {
+		if err := s.storage.DeleteObject(s.cfg.R2.BucketProcessedName, objectKey); err != nil {
+			s.logger.Printf("WARN: failed to delete R2 object from processed bucket (bucket=%s key=%s): %v", s.cfg.R2.BucketProcessedName, objectKey, err)
+		}
 	}
 
 	if err := s.contentRepo.Delete(ctx, id); err != nil {

--- a/ms_knowledge/internal/service/content_service.go
+++ b/ms_knowledge/internal/service/content_service.go
@@ -440,3 +440,12 @@ func (s *ContentService) DeleteContentSource(ctx context.Context, id uuid.UUID) 
 
 	return nil
 }
+
+// GetContentOwner returns the owner UUID for a content source (no RLS checks; for internal use)
+func (s *ContentService) GetContentOwner(ctx context.Context, id uuid.UUID) (uuid.UUID, error) {
+	content, err := s.contentRepo.GetByID(ctx, id)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("failed to get content source: %w", err)
+	}
+	return content.OwnerID, nil
+}

--- a/ms_knowledge/internal/service/content_service_test.go
+++ b/ms_knowledge/internal/service/content_service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"demo/ms_knowledge/internal/config"
 	"demo/ms_knowledge/internal/domain"
+	knowledgev1 "demo/ms_knowledge/api/proto/v1"
 
 	"github.com/google/uuid"
 )
@@ -33,17 +34,17 @@ func TestCreateUploadURL_Validation(t *testing.T) {
 	ctx := context.Background()
 	spaceID := uuid.New()
 
-	if _, _, err := svc.CreateUploadURL(ctx, uuid.Nil, "file.txt", "text/plain", 10, "title"); err == nil {
+	if _, _, _, _, err := svc.CreateUploadURL(ctx, uuid.Nil, "file.txt", "text/plain", 10, "title", knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL); err == nil {
 		t.Fatalf("expected error for empty space id")
 	}
-	if _, _, err := svc.CreateUploadURL(ctx, spaceID, "", "text/plain", 10, "title"); err == nil {
+	if _, _, _, _, err := svc.CreateUploadURL(ctx, spaceID, "", "text/plain", 10, "title", knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL); err == nil {
 		t.Fatalf("expected error for empty filename")
 	}
-	if _, _, err := svc.CreateUploadURL(ctx, spaceID, "file.txt", "", 10, "title"); err == nil {
+	if _, _, _, _, err := svc.CreateUploadURL(ctx, spaceID, "file.txt", "", 10, "title", knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL); err == nil {
 		t.Fatalf("expected error for empty mime type")
 	}
 	// Space not found
-	if _, _, err := svc.CreateUploadURL(ctx, spaceID, "file.txt", "text/plain", 10, "title"); err == nil {
+	if _, _, _, _, err := svc.CreateUploadURL(ctx, spaceID, "file.txt", "text/plain", 10, "title", knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL); err == nil {
 		t.Fatalf("expected error for space not found")
 	}
 }
@@ -62,7 +63,7 @@ func TestCreateUploadURL_Success(t *testing.T) {
 	space := &domain.Space{ID: uuid.New(), Title: "s", OwnerID: uuid.New(), CreatedAt: time.Now(), LastUpdatedAt: time.Now()}
 	_ = spaceRepo.Create(ctx, space)
 
-	content, url, err := svc.CreateUploadURL(ctx, space.ID, "note.pdf", "application/pdf", 123, "  Report  ")
+	content, url, _, _, err := svc.CreateUploadURL(ctx, space.ID, "note.pdf", "application/pdf", 123, "  Report  ", knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -212,7 +213,7 @@ func TestCreateUploadURL_DefaultsTitleToFilename(t *testing.T) {
 	space := &domain.Space{ID: uuid.New(), Title: "s", OwnerID: uuid.New(), CreatedAt: time.Now(), LastUpdatedAt: time.Now()}
 	_ = spaceRepo.Create(ctx, space)
 
-	content, _, err := svc.CreateUploadURL(ctx, space.ID, "file-name.txt", "text/plain", 1, "   ")
+	content, _, _, _, err := svc.CreateUploadURL(ctx, space.ID, "file-name.txt", "text/plain", 1, "   ", knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/ms_knowledge/internal/service/document_workflow_integration_test.go
+++ b/ms_knowledge/internal/service/document_workflow_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"demo/ms_knowledge/internal/config"
 	"demo/ms_knowledge/internal/domain"
 	"demo/ms_knowledge/internal/events"
+	knowledgev1 "demo/ms_knowledge/api/proto/v1"
 
 	"github.com/google/uuid"
 )
@@ -44,7 +45,7 @@ func TestDocumentWorkflowIntegration_SuccessfulFlow(t *testing.T) {
 	}
 
 	// Step 2: Create upload URL
-	content, uploadURL, err := contentSvc.CreateUploadURL(ctxOwner, space.ID, "test-document.pdf", "application/pdf", 1024, "Test Document")
+	content, uploadURL, _, _, err := contentSvc.CreateUploadURL(ctxOwner, space.ID, "test-document.pdf", "application/pdf", 1024, "Test Document", knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL)
 	if err != nil {
 		t.Fatalf("Failed to create upload URL: %v", err)
 	}
@@ -138,7 +139,7 @@ func TestDocumentWorkflowIntegration_FailureScenarios(t *testing.T) {
 
 	// Create space and content
 	space, _ := spaceSvc.CreateSpace(ctxOwner, "Test Space", "Test space")
-	content, _, _ := contentSvc.CreateUploadURL(ctxOwner, space.ID, "test-doc.pdf", "application/pdf", 1024, "Test Doc")
+	content, _, _, _, _ := contentSvc.CreateUploadURL(ctxOwner, space.ID, "test-doc.pdf", "application/pdf", 1024, "Test Doc", knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL)
 	contentSvc.ConfirmUpload(ctxOwner, content.ID, "original-hash")
 
 	// Test 1: Processing failure
@@ -181,7 +182,7 @@ func TestDocumentWorkflowIntegration_EventHandling(t *testing.T) {
 
 	// Setup test data
 	space, _ := spaceSvc.CreateSpace(ctxOwner, "Test Space", "Test space")
-	content, _, _ := contentSvc.CreateUploadURL(ctxOwner, space.ID, "test-doc.pdf", "application/pdf", 1024, "Test Doc")
+	content, _, _, _, _ := contentSvc.CreateUploadURL(ctxOwner, space.ID, "test-doc.pdf", "application/pdf", 1024, "Test Doc", knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL)
 	contentSvc.ConfirmUpload(ctxOwner, content.ID, "original-hash")
 	contentSvc.UpdateContentSourceStatus(ctxOwner, content.ID, domain.ContentStatusProcessing, "", "")
 
@@ -210,7 +211,7 @@ func TestDocumentWorkflowIntegration_EventHandling(t *testing.T) {
 	}
 
 	// Test failure event
-	content2, _, _ := contentSvc.CreateUploadURL(ctxOwner, space.ID, "test-doc2.pdf", "application/pdf", 1024, "Test Doc 2")
+	content2, _, _, _, _ := contentSvc.CreateUploadURL(ctxOwner, space.ID, "test-doc2.pdf", "application/pdf", 1024, "Test Doc 2", knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL)
 	contentSvc.ConfirmUpload(ctxOwner, content2.ID, "original-hash-2")
 	contentSvc.UpdateContentSourceStatus(ctxOwner, content2.ID, domain.ContentStatusProcessing, "", "")
 
@@ -251,7 +252,7 @@ func TestDocumentWorkflowIntegration_ConcurrentOperations(t *testing.T) {
 
 	// Setup
 	space, _ := spaceSvc.CreateSpace(ctxOwner, "Test Space", "Test space")
-	content, _, _ := contentSvc.CreateUploadURL(ctxOwner, space.ID, "test-doc.pdf", "application/pdf", 1024, "Test Doc")
+	content, _, _, _, _ := contentSvc.CreateUploadURL(ctxOwner, space.ID, "test-doc.pdf", "application/pdf", 1024, "Test Doc", knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL)
 	contentSvc.ConfirmUpload(ctxOwner, content.ID, "original-hash")
 
 	// Test concurrent status updates (simulates race conditions)
@@ -305,8 +306,8 @@ func TestDocumentWorkflowIntegration_SpaceContentIntegrity(t *testing.T) {
 	space2, _ := spaceSvc.CreateSpace(ctxOwner, "Space 2", "Space 2")
 
 	// Add content to both spaces
-	_, _, _ = contentSvc.CreateUploadURL(ctxOwner, space1.ID, "doc1.pdf", "application/pdf", 1024, "Doc 1")
-	_, _, _ = contentSvc.CreateUploadURL(ctxOwner, space2.ID, "doc2.pdf", "application/pdf", 1024, "Doc 2")
+	_, _, _, _, _ = contentSvc.CreateUploadURL(ctxOwner, space1.ID, "doc1.pdf", "application/pdf", 1024, "Doc 1", knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL)
+	_, _, _, _, _ = contentSvc.CreateUploadURL(ctxOwner, space2.ID, "doc2.pdf", "application/pdf", 1024, "Doc 2", knowledgev1.DownloadObjectKind_DOWNLOAD_OBJECT_KIND_ORIGINAL)
 
 	// Create orphaned content (simulate space deletion)
 	orphanedSpaceID := uuid.New()


### PR DESCRIPTION
## Summary

This PR refactors the R2 bucket integration to simplify object key management and improve consistency across the document upload/download workflow. The main changes include:

- **Simplified gRPC API**: Removed redundant `object_kind` parameter from `ConfirmUploadRequest` to streamline the API
- **Unified object key handling**: Document processing now uses consistent object keys (`{owner_id}/spaces/{space_id}/content/{content_source_id}/{filename}`) for both source and processed documents
- **Improved document workflow**: Updated document repository and service to use object keys instead of blob hashes for file operations
- **Enhanced error handling**: Added validation for missing `original_object_key` in document processing events
- **Updated test coverage**: All tests updated to reflect the new object key-based approach
- Rebert #45 #46 

## Key Changes

### gRPC API Changes
- Removed `object_kind` parameter from `ConfirmUploadRequest` message
- Simplified upload confirmation workflow in `content_service.go`
- Updated protobuf definitions and generated Go code

### Document Processing Service
- `DocumentRepository` methods now use `object_key` instead of `blob_hash` parameters
- `DocumentProcessService` validates presence of `original_object_key` in events
- Processed documents are now stored using the same object key as source documents
- Improved error messages and logging

### Test Updates
- All test cases updated to include proper `original_object_key` values
- Added test case for missing `original_object_key` validation
- Integration tests updated to reflect new object key patterns

## Files Changed
- `ms_document_process/app/repository/document_repository.py`
- `ms_document_process/app/service/document_service.py` 
- `ms_document_process/tests/test_document_service.py`
- `ms_document_process/tests/test_kafka_integration.py`
- `ms_knowledge/api/proto/v1/knowledge.proto`
- `ms_knowledge/api/proto/v1/knowledge.pb.go`
- `ms_knowledge/cmd/main.go`
- `ms_knowledge/internal/server/grpc.go`
- `ms_knowledge/internal/service/content_service.go`
- `ms_knowledge/internal/service/content_service_test.go`
- `ms_knowledge/internal/service/document_workflow_integration_test.go`

## Test Plan
- [x] Unit tests for document repository and service methods
- [x] Integration tests for Kafka event processing
- [x] gRPC server tests for upload/download URL generation
- [x] End-to-end document workflow tests
- [ ] Manual testing of document upload and processing flow
