### PR TITLE
Dev mode: hot reload via docker-compose.dev + Air/Watchdog; add dev Dockerfiles and scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ venv.bak/
 *.test
 # Output of go build
 *.out
+# Air hot reload build cache
+tmp/
+*.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ venv.bak/
 # Air hot reload build cache
 tmp/
 *.tmp
+# Microservice binaries
+ms_*/app
+ms_*/server
+ms_*/test_app

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,15 +72,36 @@ pip install -r requirements.txt
 python app/main.py
 ```
 
-### Full Stack Development
+### Development Modes
+
+#### Development Mode (Hot Reloading)
+For development with automatic code reloading when files change:
+```bash
+# Start development environment with hot reloading
+./scripts/dev-up.sh
+# OR manually:
+# docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+
+# After making code changes, restart specific service:
+./scripts/dev-restart.sh frontend
+./scripts/dev-restart.sh ms_user
+# OR manually:
+# docker-compose -f docker-compose.yml -f docker-compose.dev.yml restart <service_name>
+
+# View logs for a specific service
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml logs -f [service-name]
+
+# Stop all services
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml down
+```
+
+#### Production Mode
+For production builds without hot reloading:
 ```bash
 # Start all services with Docker Compose
 docker-compose up -d
 
-# Start specific services
-docker-compose up backend-go frontend
-
-# Rebuild containers after changes
+# Rebuild containers after changes (slower)
 docker-compose build
 docker-compose up --build
 
@@ -91,35 +112,25 @@ docker-compose logs -f [service-name]
 docker-compose down
 ```
 
-### Frontend Development
+### Local Development (without Docker)
+
+#### Frontend Development
 ```bash
 cd frontend
 npm install
 npm run dev
 ```
 
-### Go Microservice Development
+#### Go Microservice Development
 ```bash
 cd ms_user # (or other Go microservice)
 go mod download
 go run ./cmd/server/main.go
 ```
 
-### Python Microservice Development
+#### Python Microservice Development
 ```bash
 cd ms_ml # (or other Python microservice)
 pip install -r requirements.txt
 python app/main.py
-```
-
-### Full Stack Development
-```bash
-# Start all services with Docker Compose
-docker-compose up -d
-
-# View logs for a specific service
-docker-compose logs -f [service-name]
-
-# Stop all services
-docker-compose down
 ```

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,60 @@
+# Development Docker Compose Override
+# This file enables hot reloading for all services during development
+# 
+# Usage:
+#   Development mode:  docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
+#   Production mode:   docker-compose up
+#
+# After code changes, simply restart the specific service:
+#   docker-compose -f docker-compose.yml -f docker-compose.dev.yml restart frontend
+#   docker-compose -f docker-compose.yml -f docker-compose.dev.yml restart ms_user
+
+services:
+  # Frontend with hot reloading
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+      - /app/.next
+    environment:
+      - NODE_ENV=development
+    ports:
+      - "3002:3002"
+    command: ["npx", "next", "dev", "--turbopack", "--port", "3002", "--hostname", "0.0.0.0"]
+
+  # Go microservices with hot reloading using Air
+  ms_user:
+    build:
+      context: ./ms_user
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./ms_user:/app
+      - /app/tmp
+    environment:
+      - GO_ENV=development
+
+  ms_knowledge:
+    build:
+      context: .
+      dockerfile: ms_knowledge/Dockerfile.dev
+    volumes:
+      - ./ms_knowledge:/app/ms_knowledge
+      - ./ms_user:/app/ms_user
+      - /app/ms_knowledge/tmp
+    environment:
+      - GO_ENV=development
+
+  # Python microservices with hot reloading using watchdog
+  ms_document_process:
+    build:
+      context: ./ms_document_process
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./ms_document_process:/app
+      - /app/__pycache__
+    environment:
+      - PYTHON_ENV=development
+      - PYTHONPATH=/app

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,15 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+# Copy source code (will be mounted as volume in dev)
+COPY . .
+
+EXPOSE 3002
+
+# Use development server with hot reloading (skip proto generation)
+CMD ["npx", "next", "dev", "--turbopack", "--port", "3002", "--hostname", "0.0.0.0"]

--- a/ms_document_process/Dockerfile.dev
+++ b/ms_document_process/Dockerfile.dev
@@ -1,0 +1,28 @@
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+WORKDIR /app
+
+# Install watchdog for hot reloading
+RUN pip install --no-cache-dir poetry watchdog
+
+# Install only dependency metadata first for better caching
+COPY pyproject.toml poetry.lock ./
+
+# Force Poetry to install into the global environment, not a venv
+ENV POETRY_VIRTUALENVS_CREATE=false \
+    POETRY_VIRTUALENVS_IN_PROJECT=false
+
+RUN poetry install --no-root --no-interaction --no-ansi
+
+# Copy source code (will be mounted as volume)
+COPY . .
+
+EXPOSE 50053
+
+ENV PYTHONPATH=/app
+
+# Use watchdog for hot reloading
+CMD ["python", "-m", "watchdog", "auto-restart", "--directory=.", "--pattern=*.py", "--recursive", "--", "python", "-m", "app.main"]

--- a/ms_knowledge/.air.toml
+++ b/ms_knowledge/.air.toml
@@ -1,0 +1,44 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main ./cmd/main.go"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_root = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/ms_knowledge/Dockerfile.dev
+++ b/ms_knowledge/Dockerfile.dev
@@ -1,0 +1,30 @@
+FROM golang:1.24
+
+# Install build dependencies for CGO
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy go.mod files for both ms_knowledge and ms_user
+COPY ms_knowledge/go.mod ms_knowledge/go.sum ./ms_knowledge/
+COPY ms_user /app/ms_user
+
+# Download dependencies
+WORKDIR /app/ms_knowledge
+RUN go mod download
+
+# Install air for hot reloading (after go mod setup)
+RUN go install github.com/air-verse/air@latest
+
+WORKDIR /app
+
+# Copy source code (will be mounted as volume)
+COPY ms_knowledge/ ./ms_knowledge/
+
+EXPOSE 50052
+
+# Use air for hot reloading
+WORKDIR /app/ms_knowledge
+CMD ["air", "-c", ".air.toml"]

--- a/ms_user/.air.toml
+++ b/ms_user/.air.toml
@@ -1,0 +1,44 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main ./cmd/main.go"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_root = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/ms_user/Dockerfile.dev
+++ b/ms_user/Dockerfile.dev
@@ -1,0 +1,18 @@
+FROM golang:1.23-alpine
+
+WORKDIR /app
+
+# Copy go.mod and download dependencies first
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Install air for hot reloading (after go mod setup)
+RUN go install github.com/air-verse/air@latest
+
+# Copy source code (will be mounted as volume)
+COPY . .
+
+EXPOSE 50051 8081
+
+# Use air for hot reloading
+CMD ["air", "-c", ".air.toml"]

--- a/scripts/dev-restart.sh
+++ b/scripts/dev-restart.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Restart specific service in development mode
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <service_name>"
+    echo "Available services: frontend, ms_user, ms_knowledge, ms_document_process, ngrok"
+    exit 1
+fi
+
+SERVICE_NAME=$1
+
+echo "Restarting $SERVICE_NAME in development mode..."
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml restart $SERVICE_NAME
+
+echo "$SERVICE_NAME restarted successfully!"
+echo "To view logs: docker-compose -f docker-compose.yml -f docker-compose.dev.yml logs -f $SERVICE_NAME"

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Start development environment with hot reloading
+echo "Starting development environment with hot reloading..."
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+
+echo ""
+echo "Development environment started!"
+echo ""
+echo "To restart a service after code changes:"
+echo "  docker-compose -f docker-compose.yml -f docker-compose.dev.yml restart <service_name>"
+echo ""
+echo "To view logs:"
+echo "  docker-compose -f docker-compose.yml -f docker-compose.dev.yml logs -f <service_name>"
+echo ""
+echo "To stop the development environment:"
+echo "  docker-compose -f docker-compose.yml -f docker-compose.dev.yml down"
+echo ""


### PR DESCRIPTION
## **Summary**
- Add development hot-reload workflow using docker-compose override.
- Introduce dev Dockerfiles for frontend, Go, and Python services.
- Add Air/Watchdog configs for live reload and helper scripts.

## **Key changes**
- Add docker-compose.dev.yml to enable dev mode overrides (volumes, commands).
- Frontend: add Dockerfile.dev with Next.js dev server on port 3002.
- Go services: add Dockerfile.dev and .air.toml for ms_user and ms_knowledge (Air hot reload).
- Python service: add Dockerfile.dev for ms_document_process with watchdog auto-restart.
- Docs: update CLAUDE.md with clear Dev vs Prod instructions and scripts usage.
- Scripts: add scripts/dev-up.sh and scripts/dev-restart.sh for convenience.
- Gitignore: ignore Air tmp builds and local binaries.

## **Notes**
- Dev images favor iteration speed over minimal size.
- Prod remains unchanged; use plain docker-compose.yml for production builds.
- Follow-up: consider updating MILESTONE/implementation-checklist.md to mark dev tooling setup for infra.

## **Files touched**
- .gitignore
- CLAUDE.md
- docker-compose.dev.yml (new)
- frontend/Dockerfile.dev (new)
- ms_user/.air.toml, ms_user/Dockerfile.dev (new)
- ms_knowledge/.air.toml, ms_knowledge/Dockerfile.dev (new)
- ms_document_process/Dockerfile.dev (new)
- scripts/dev-up.sh, scripts/dev-restart.sh (new)
