### PR TITLE
Fix: robust content upload (binary/int64), cache refresh, and content source UI

### DIFF
--- a/frontend/src/api/actions/contentActions.ts
+++ b/frontend/src/api/actions/contentActions.ts
@@ -45,7 +45,10 @@ async function listContentSourcesCore(
     }
 
     const response = await client.listContentSources(request, { headers });
-    const sanitizedItems = response.items.map(item => sanitizeProtobufForJson(item));
+    const { normalizeContentSourceForClient } = await import('./utils');
+    const sanitizedItems = response.items
+      .map(item => sanitizeProtobufForJson(item))
+      .map(item => normalizeContentSourceForClient(item));
     return { ok: true, data: sanitizedItems };
   } catch (error) {
     if (isUnauthorizedError(error)) {
@@ -123,7 +126,10 @@ export async function listContentSourcesUncached(
     }
 
     const response = await client.listContentSources(request as ListContentSourcesRequest, { headers });
-    const sanitizedItems = response.items.map(item => sanitizeProtobufForJson(item));
+    const { normalizeContentSourceForClient } = await import('./utils');
+    const sanitizedItems = response.items
+      .map(item => sanitizeProtobufForJson(item))
+      .map(item => normalizeContentSourceForClient(item));
     return { ok: true, data: sanitizedItems };
   } catch (error) {
     if (isUnauthorizedError(error)) {

--- a/frontend/src/api/actions/contentActions.ts
+++ b/frontend/src/api/actions/contentActions.ts
@@ -96,6 +96,45 @@ export async function listContentSources(
   }
 }
 
+// Uncached variant for short-interval polling to avoid 60s cache staleness
+export async function listContentSourcesUncached(
+  spaceId: string,
+  status?: 'uploading' | 'uploaded' | 'processing' | 'processed' | 'failed'
+): Promise<ActionResult<ContentSource[]>> {
+  try {
+    const { userId } = await auth();
+    if (!userId) return { ok: false, error: { code: 'UNAUTHORIZED', message: 'User not authenticated' } };
+
+    const headers = await createAuthHeaders();
+    const client = getKnowledgeServiceClient();
+
+    const request: Partial<ListContentSourcesRequest> = { spaceId };
+    if (status) {
+      const statusMap = {
+        uploading: ContentStatus.UPLOADING,
+        uploaded: ContentStatus.UPLOADED,
+        processing: ContentStatus.PROCESSING,
+        processed: ContentStatus.PROCESSED,
+        failed: ContentStatus.FAILED,
+      };
+      if (status in statusMap) {
+        request.status = statusMap[status as keyof typeof statusMap];
+      }
+    }
+
+    const response = await client.listContentSources(request as ListContentSourcesRequest, { headers });
+    const sanitizedItems = response.items.map(item => sanitizeProtobufForJson(item));
+    return { ok: true, data: sanitizedItems };
+  } catch (error) {
+    if (isUnauthorizedError(error)) {
+      logAuthFailure('listContentSourcesUncached', error);
+    } else {
+      console.error('listContentSourcesUncached error:', error);
+    }
+    return { ok: false, error: sanitizeError(error) };
+  }
+}
+
 export async function createUploadURL(
   request: CreateUploadURLRequest
 ): Promise<ActionResult<CreateUploadURLResponse>> {

--- a/frontend/src/api/actions/contentActions.ts
+++ b/frontend/src/api/actions/contentActions.ts
@@ -106,7 +106,10 @@ export async function createUploadURL(
     const client = getKnowledgeServiceClient();
     const headers = await createAuthHeaders();
 
-    const response = await client.createUploadURL(request, { headers });
+    // Use utility to rebuild/normalize request types (sizeBytes, enum fields)
+    const { rebuildCreateUploadURLRequest } = await import('./utils');
+    const rebuilt = rebuildCreateUploadURLRequest(request as CreateUploadURLRequest);
+    const response = await client.createUploadURL(rebuilt, { headers });
     // Sanitize response (contains ContentSource with size_bytes BigInt field)
     const sanitizedResponse = sanitizeProtobufForJson(response);
     return { ok: true, data: sanitizedResponse };

--- a/frontend/src/api/actions/contentActions.ts
+++ b/frontend/src/api/actions/contentActions.ts
@@ -186,8 +186,17 @@ export async function confirmUpload(
     // Revalidate content lists for this space
     if (sanitizedResponse && (sanitizedResponse as any).spaceId) {
       const sid = (sanitizedResponse as any).spaceId as string;
+      // Refresh content lists within the space (documents panel)
       revalidateTag(`content-sources-${sid}`);
+      // Refresh the specific space cache (e.g., stats/counts used in detail views)
+      revalidateTag(`space-${sid}`);
+      // Refresh the spaces list (gallery/list page shows docs count in cards)
+      if (userId) {
+        revalidateTag(`spaces-list-${userId}`);
+      }
+      // Trigger page-level revalidation for both the detail and list pages
       revalidatePath(`/spaces/${sid}`);
+      revalidatePath('/spaces');
     }
     return { ok: true, data: sanitizedResponse };
   } catch (error) {

--- a/frontend/src/api/actions/utils.ts
+++ b/frontend/src/api/actions/utils.ts
@@ -1,6 +1,6 @@
 import { auth } from '@clerk/nextjs/server';
 import { ConnectError } from '@bufbuild/connect';
-import { SpaceFilters, CreateUploadURLRequest, DownloadObjectKind } from '../generated/v1/knowledge_pb';
+import { SpaceFilters, CreateUploadURLRequest, DownloadObjectKind, ContentStatus } from '../generated/v1/knowledge_pb';
 import { protoInt64 } from '@bufbuild/protobuf';
 
 /**
@@ -214,6 +214,23 @@ export function rebuildCreateUploadURLRequest(input: CreateUploadURLRequest): Cr
   }
 
   return rebuilt;
+}
+
+/**
+ * Normalize a content source-like object for client use:
+ * - Ensures enum `status` is a number (not a string from toJson)
+ */
+export function normalizeContentSourceForClient<T extends { status?: unknown }>(obj: T): T {
+  try {
+    const status = (obj as any).status;
+    if (typeof status === 'string') {
+      const numeric = (ContentStatus as any)[status];
+      if (typeof numeric === 'number') {
+        (obj as any).status = numeric;
+      }
+    }
+  } catch {}
+  return obj;
 }
 
 /**

--- a/frontend/src/api/actions/utils.ts
+++ b/frontend/src/api/actions/utils.ts
@@ -1,6 +1,7 @@
 import { auth } from '@clerk/nextjs/server';
 import { ConnectError } from '@bufbuild/connect';
-import { SpaceFilters } from '../generated/v1/knowledge_pb';
+import { SpaceFilters, CreateUploadURLRequest, DownloadObjectKind } from '../generated/v1/knowledge_pb';
+import { protoInt64 } from '@bufbuild/protobuf';
 
 /**
  * Helper function to create headers with JWT token
@@ -174,6 +175,45 @@ export function sanitizeProtobufForJson<T>(obj: T): T {
   }
 
   return result;
+}
+
+/**
+ * Rebuilds a CreateUploadURLRequest to ensure numeric and enum fields are properly typed
+ * before binary serialization. Accepts a typed message that may have been de-serialized
+ * across server action boundaries and returns a normalized instance.
+ */
+export function rebuildCreateUploadURLRequest(input: CreateUploadURLRequest): CreateUploadURLRequest {
+  const rebuilt = new CreateUploadURLRequest({
+    spaceId: String((input as any).spaceId ?? input.spaceId ?? ''),
+    filename: String((input as any).filename ?? input.filename ?? ''),
+    mimeType: String((input as any).mimeType ?? input.mimeType ?? ''),
+    title: String((input as any).title ?? input.title ?? ''),
+  });
+
+  // Normalize size_bytes (int64)
+  try {
+    const rawSize = (input as any).sizeBytes ?? 0;
+    rebuilt.sizeBytes = protoInt64.parse(rawSize);
+  } catch (e) {
+    rebuilt.sizeBytes = (CreateUploadURLRequest as any).prototype.sizeBytes ?? 0;
+    console.warn('rebuildCreateUploadURLRequest: failed to normalize sizeBytes', e);
+  }
+
+  // Normalize object_kind (enum)
+  const rawKind = (input as any).objectKind ?? (input as any).object_kind ?? input.objectKind;
+  if (typeof rawKind === 'number') {
+    rebuilt.objectKind = rawKind as any;
+  } else if (typeof rawKind === 'string') {
+    const exact = (DownloadObjectKind as any)[rawKind];
+    const prefixed = (DownloadObjectKind as any)[`DOWNLOAD_OBJECT_KIND_${rawKind}`];
+    if (typeof exact === 'number') rebuilt.objectKind = exact;
+    else if (typeof prefixed === 'number') rebuilt.objectKind = prefixed;
+    else rebuilt.objectKind = DownloadObjectKind.ORIGINAL;
+  } else {
+    rebuilt.objectKind = input.objectKind ?? DownloadObjectKind.ORIGINAL;
+  }
+
+  return rebuilt;
 }
 
 /**

--- a/frontend/src/app/spaces/[spaceId]/@uploadModal/(.)upload/page.tsx
+++ b/frontend/src/app/spaces/[spaceId]/@uploadModal/(.)upload/page.tsx
@@ -1,21 +1,25 @@
 "use client";
 import UploadModal from '../UploadModal';
+import { useParams, useSearchParams } from 'next/navigation';
 
-interface UploadModalPageProps {
-  params: {
-    spaceId: string;
-  };
-  searchParams: { tab?: 'file' | 'google-drive' | 'link' | 'text' };
-}
+type AllowedTab = 'file' | 'google-drive' | 'link' | 'text';
 
-export default function UploadModalPage({ params, searchParams }: UploadModalPageProps) {
-  const { spaceId } = params;
+export default function UploadModalPage() {
+  const params = useParams();
+  const searchParams = useSearchParams();
+
+  const rawSpaceId = (params as Record<string, string | string[]>).spaceId;
+  const spaceId = Array.isArray(rawSpaceId) ? rawSpaceId[0] : rawSpaceId;
+
+  const tabParam = searchParams.get('tab');
+  const autoOpenTab: AllowedTab =
+    tabParam === 'google-drive' || tabParam === 'link' || tabParam === 'text' ? (tabParam as AllowedTab) : 'file';
 
   return (
     <UploadModal
       spaceId={spaceId}
       isOpen={true}
-      autoOpenTab={searchParams?.tab ?? 'file'}
+      autoOpenTab={autoOpenTab}
       onUploadComplete={() => {}}
       onClose={() => {}}
     />

--- a/frontend/src/app/spaces/[spaceId]/components/ContentSourcesSection.tsx
+++ b/frontend/src/app/spaces/[spaceId]/components/ContentSourcesSection.tsx
@@ -27,6 +27,31 @@ export default function ContentSourcesSection({ spaceId, contentSources, classNa
   const [progressById, setProgressById] = useState<Record<string, number>>({});
 
   useEffect(() => {
+    // When the component mounts or window regains focus, fetch the latest sources
+    // uncached to avoid stale UI after closing the upload modal.
+    const refreshLatest = async () => {
+      try {
+        const { listContentSourcesUncached } = await import('@/api/actions/contentActions');
+        const res = await listContentSourcesUncached(spaceId, 'processed');
+        if (res.ok && res.data) {
+          setSources((prev) => {
+            // Merge: keep any non-processed placeholders, replace processed list
+            const placeholders = prev.filter((s) => s.status !== ContentStatus.PROCESSED);
+            const processed = res.data ?? [];
+            const next = [...processed, ...placeholders];
+            return next;
+          });
+        }
+      } catch {}
+    };
+
+    const onFocus = () => { void refreshLatest(); };
+    void refreshLatest();
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, [spaceId]);
+
+  useEffect(() => {
     const onCreated = (e: CustomEvent<ContentSource>) => {
       const detail = e.detail;
       setSources((prev) => {

--- a/frontend/src/app/spaces/components/AccessLevelModal.tsx
+++ b/frontend/src/app/spaces/components/AccessLevelModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Space, UpdateSpaceRequest } from '@/api/generated/v1/knowledge_pb';
+import { Space } from '@/api/generated/v1/knowledge_pb';
 import { updateSpace } from '@/api/actions/spaceActions';
 import {
   Dialog,
@@ -57,16 +57,14 @@ export function AccessLevelModal({ space, open, onOpenChange }: AccessLevelModal
 
     setIsSaving(true);
     try {
-      const updateRequest = new UpdateSpaceRequest({
+      const result = await updateSpace(space.id, {
         id: space.id,
         title: space.title,
         description: space.description,
         keywords: space.keywords || [],
         icon: space.icon || '',
         accessLevel: selectedLevel,
-      });
-
-      const result = await updateSpace(space.id, updateRequest);
+      } as any);
       if (result.ok) {
         onOpenChange(false);
         toast({

--- a/frontend/src/app/spaces/components/SpaceCard.tsx
+++ b/frontend/src/app/spaces/components/SpaceCard.tsx
@@ -62,15 +62,16 @@ export default function SpaceCard({
     }
   };
 
-  const formatDate = (date: Date | string | undefined) => {
-    if (!date) return '';
-    const d = typeof date === 'string' ? new Date(date) : date;
-    return d.toLocaleDateString();
-  };
-
   const formatTimestamp = (timestamp: any) => {
     const date = safeTimestampToDate(timestamp);
-    return date ? date.toLocaleDateString() : '';
+    return date
+      ? new Intl.DateTimeFormat('en-US', {
+          timeZone: 'UTC',
+          year: 'numeric',
+          month: 'numeric',
+          day: 'numeric',
+        }).format(date)
+      : '';
   };
 
   return (

--- a/frontend/src/app/spaces/hooks/useProcessingPoller.ts
+++ b/frontend/src/app/spaces/hooks/useProcessingPoller.ts
@@ -54,8 +54,8 @@ export function useProcessingPoller({ spaceId, onUpdates, candidateIds, interval
         return;
       }
 
-      const { listContentSources } = await import('@/api/actions/contentActions');
-      const result = await listContentSources(spaceId, 'processing');
+      const { listContentSourcesUncached } = await import('@/api/actions/contentActions');
+      const result = await listContentSourcesUncached(spaceId, 'processing');
       if (!result.ok || !result.data) {
         // Retry later with backoff
         backoffRef.current = Math.min(backoffRef.current * 1.5, 15000);
@@ -70,8 +70,8 @@ export function useProcessingPoller({ spaceId, onUpdates, candidateIds, interval
       // to processed/failed. Do not return early; continue to check terminal sets.
 
       // Also fetch any recently completed in case we missed the transition
-      const completedRes = await listContentSources(spaceId, 'processed');
-      const failedRes = await listContentSources(spaceId, 'failed');
+      const completedRes = await listContentSourcesUncached(spaceId, 'processed');
+      const failedRes = await listContentSourcesUncached(spaceId, 'failed');
       let completed = completedRes.ok && completedRes.data ? completedRes.data : [];
       let failed = failedRes.ok && failedRes.data ? failedRes.data : [];
 

--- a/frontend/src/app/spaces/hooks/useUpload.ts
+++ b/frontend/src/app/spaces/hooks/useUpload.ts
@@ -3,7 +3,7 @@
 import { useState, useCallback } from 'react';
 // Server actions are dynamically imported at call time to avoid stale action IDs during HMR
 import { ContentSource, ContentStatus, DownloadObjectKind, CreateUploadURLRequest } from '@/api/generated/v1/knowledge_pb';
-import { Timestamp } from '@bufbuild/protobuf';
+import { Timestamp, protoInt64 } from '@bufbuild/protobuf';
 
 interface UploadOptions {
   spaceId: string;
@@ -43,11 +43,14 @@ export function useUpload({ spaceId, onUploadComplete, onUploadError }: UploadOp
     try {
       // Step 1: Get upload URL from server action (dynamic import to avoid stale action id)
       const { createUploadURL } = await import('@/api/actions/contentActions');
+      
+      const parsedSizeBytes = protoInt64.parse(file.size);
+      
       const uploadUrlResult = await createUploadURL(new CreateUploadURLRequest({
         spaceId,
         filename: file.name,
         mimeType: file.type,
-        sizeBytes: BigInt(file.size),
+        sizeBytes: parsedSizeBytes,
         objectKind: DownloadObjectKind.ORIGINAL
       }));
 
@@ -69,7 +72,7 @@ export function useUpload({ spaceId, onUploadComplete, onUploadError }: UploadOp
           spaceId,
           title: file.name,
           mimeType: file.type || 'application/octet-stream',
-          sizeBytes: BigInt(file.size),
+          sizeBytes: protoInt64.parse(file.size),
           status: ContentStatus.UPLOADING,
           createdAt: Timestamp.fromDate(new Date()),
           updatedAt: Timestamp.fromDate(new Date()),

--- a/frontend/src/app/spaces/hooks/useUpload.ts
+++ b/frontend/src/app/spaces/hooks/useUpload.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback } from 'react';
 // Server actions are dynamically imported at call time to avoid stale action IDs during HMR
-import { ContentSource, ContentStatus, DownloadObjectKind, CreateUploadURLRequest } from '@/api/generated/v1/knowledge_pb';
+import { ContentSource, ContentStatus, DownloadObjectKind } from '@/api/generated/v1/knowledge_pb';
 import { Timestamp, protoInt64 } from '@bufbuild/protobuf';
 
 interface UploadOptions {
@@ -44,15 +44,14 @@ export function useUpload({ spaceId, onUploadComplete, onUploadError }: UploadOp
       // Step 1: Get upload URL from server action (dynamic import to avoid stale action id)
       const { createUploadURL } = await import('@/api/actions/contentActions');
       
-      const parsedSizeBytes = protoInt64.parse(file.size);
-      
-      const uploadUrlResult = await createUploadURL(new CreateUploadURLRequest({
+      const uploadUrlResult = await createUploadURL({
         spaceId,
         filename: file.name,
         mimeType: file.type,
-        sizeBytes: parsedSizeBytes,
-        objectKind: DownloadObjectKind.ORIGINAL
-      }));
+        sizeBytes: file.size,
+        objectKind: DownloadObjectKind.ORIGINAL,
+        title: file.name,
+      } as any);
 
       if (!uploadUrlResult.ok || !uploadUrlResult.data) {
         throw new Error(uploadUrlResult.error?.message || 'Failed to create upload URL');

--- a/frontend/src/components/content/ContentSourceCard.tsx
+++ b/frontend/src/components/content/ContentSourceCard.tsx
@@ -16,6 +16,7 @@ import {
 import { cn } from '@/lib/utils';
 import { ContentSource, ContentStatus } from '@/api/generated/v1/knowledge_pb';
 import { formatDate, fileTypeLabel } from '@/lib/contentSource';
+import { safeTimestampToDate } from '@/lib/types';
 
 export interface ContentSourceCardProps {
   contentSource: ContentSource;
@@ -111,7 +112,12 @@ export default function ContentSourceCard({ contentSource, onView, onDownload, o
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-3">
           <span className="text-xs px-3 py-1 border rounded-md">{fileTypeLabel(contentSource.mimeType, contentSource.source)}</span>
-          <div className="text-xs text-gray-500">Added {contentSource.createdAt ? formatDate(new Date(Number(contentSource.createdAt.seconds) * 1000)) : 'Unknown'}</div>
+          <div className="text-xs text-gray-500">
+            {(() => {
+              const created = safeTimestampToDate(contentSource.createdAt as any);
+              return `Added ${created ? formatDate(created) : 'Unknown'}`;
+            })()}
+          </div>
         </div>
         <div className="flex items-center gap-3" onClick={(e) => e.stopPropagation()}>
           {contentSource.status === ContentStatus.PROCESSED && (


### PR DESCRIPTION
## **Summary**
- Fix content upload issues by correctly handling binary payloads and int64 fields.
- Refactor cache usage to avoid stale UI after uploads; add uncached list APIs where needed.
- Fix content source card loading/formatting issues and improve space revalidation.

**Fixes**
- Binary/int64 handling during upload: normalize `sizeBytes` and enums before RPC; use `protoInt64`.
- Content source card date rendering: use safe timestamp conversion to prevent 'Invalid Date'.
- Cache staleness after upload: short-interval polling uses uncached listing; aggressive revalidation of tags/paths.
- Upload modal routing: robust `spaceId`/`tab` parsing via `useParams`/`useSearchParams`.

## **Key changes**
- Add `rebuildCreateUploadURLRequest` utility to normalize numbers/enums prior to serialization.
- Add `normalizeContentSourceForClient` to ensure enum `status` is numeric for client logic.
- Introduce `listContentSourcesUncached(spaceId, status)` and adopt it in poller and refresh flows.
- Enhance `confirmUpload` revalidation: revalidate content lists, space detail, and spaces list.
- Fix `ContentSourceCard` createdAt display using `safeTimestampToDate`.
- Tweak `SpaceCard` timestamp formatting for stable UTC display.
- Upload modal now derives `spaceId` and `tab` safely from the router.

## **How to test**
```bash
# 1) Upload a file in a space
# Expect: immediate card appears with UPLOADING -> PROCESSING -> PROCESSED without manual refresh

# 2) Verify dates
# Expect: 'Added' shows a valid, properly formatted date, no 'Invalid Date'

# 3) Polling
# Expect: processing poller updates cards using uncached listing; no 60s cache staleness

# 4) Modal deep links
# Visit /spaces/<spaceId>/upload?tab=google-drive (or link/text)
# Expect: modal opens on the requested tab
```

## **Files touched (highlights)**
- frontend/src/api/actions/contentActions.ts
- frontend/src/api/actions/utils.ts
- frontend/src/app/spaces/[spaceId]/@uploadModal/(.)upload/page.tsx
- frontend/src/app/spaces/[spaceId]/components/ContentSourcesSection.tsx
- frontend/src/app/spaces/hooks/useProcessingPoller.ts
- frontend/src/app/spaces/hooks/useUpload.ts
- frontend/src/components/content/ContentSourceCard.tsx
- frontend/src/app/spaces/components/SpaceCard.tsx
