### PR TITLE
refactor(content_service): update object key format in buildObjectKey and bump Go 1.25

### DIFF
--- a/ms_knowledge/Dockerfile.dev
+++ b/ms_knowledge/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.24
+FROM golang:1.25
 
 # Install build dependencies for CGO
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ms_knowledge/internal/service/content_service.go
+++ b/ms_knowledge/internal/service/content_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -60,9 +61,14 @@ func (s *ContentService) scopeContentFilterToOwner(ctx context.Context, filter d
 }
 
 // buildObjectKey constructs the R2 object key including the owner prefix and space/content path
+// New format: <userId>/spaces/<spaceId>/content/<contentSourceId>+<media_extension>
 func buildObjectKey(ownerID, spaceID, contentID uuid.UUID, filename string) string {
-	// <userId>/spaces/<spaceId>/content/<contentSourceId>/<fileName>
-	return ownerID.String() + "/spaces/" + spaceID.String() + "/content/" + contentID.String() + "/" + strings.TrimSpace(filename)
+	// derive extension from filename
+	ext := strings.TrimPrefix(filepath.Ext(strings.TrimSpace(filename)), ".")
+	if ext == "" {
+		ext = "bin"
+	}
+	return ownerID.String() + "/spaces/" + spaceID.String() + "/content/" + contentID.String() + "+" + strings.ToLower(ext)
 }
 
 // getBucketFromObjectKind returns the appropriate bucket name based on the object kind
@@ -143,7 +149,7 @@ func (s *ContentService) CreateUploadURL(ctx context.Context, spaceID uuid.UUID,
 		// Log error but don't fail the upload process itself
 	}
 
-	// Generate object key based on persisted content ID
+	// Generate object key based on persisted content ID (new format handled by buildObjectKey)
 	objectKey := buildObjectKey(ownerUUID, spaceID, content.ID, filename)
 
 	// Get appropriate bucket based on object kind
@@ -186,7 +192,8 @@ func (s *ContentService) ConfirmUpload(ctx context.Context, contentID uuid.UUID,
 
 	// Emit document.uploaded event
 	if s.producer != nil {
-		objectKey := buildObjectKey(content.OwnerID, content.SpaceID, content.ID, strings.TrimSpace(content.Source))
+		// Emit with configured key format
+		objectKey := buildObjectKey(content.OwnerID, content.SpaceID, content.ID, content.Source)
 		evt := events.DocumentUploadedEvent{
 			ContentSourceID:   content.ID,
 			OriginalBlobHash:  blobHash,
@@ -383,8 +390,8 @@ func (s *ContentService) GenerateDownloadURL(ctx context.Context, contentID uuid
 		expires = 15 * time.Minute
 	}
 
-	filename := content.Source
-	objectKey := buildObjectKey(content.OwnerID, content.SpaceID, content.ID, filename)
+	// Build object key and generate presigned URL
+	objectKey := buildObjectKey(content.OwnerID, content.SpaceID, content.ID, strings.TrimSpace(content.Source))
 
 	url, err := s.storage.GeneratePresignedDownloadURL(bucket, objectKey, expires)
 	if err != nil {

--- a/ms_knowledge/internal/service/content_service.go
+++ b/ms_knowledge/internal/service/content_service.go
@@ -61,14 +61,14 @@ func (s *ContentService) scopeContentFilterToOwner(ctx context.Context, filter d
 }
 
 // buildObjectKey constructs the R2 object key including the owner prefix and space/content path
-// New format: <userId>/spaces/<spaceId>/content/<contentSourceId>+<media_extension>
+// New format: <userId>/spaces/<spaceId>/content/<contentSourceId>.<media_extension>
 func buildObjectKey(ownerID, spaceID, contentID uuid.UUID, filename string) string {
 	// derive extension from filename
 	ext := strings.TrimPrefix(filepath.Ext(strings.TrimSpace(filename)), ".")
 	if ext == "" {
 		ext = "bin"
 	}
-	return ownerID.String() + "/spaces/" + spaceID.String() + "/content/" + contentID.String() + "+" + strings.ToLower(ext)
+	return ownerID.String() + "/spaces/" + spaceID.String() + "/content/" + contentID.String() + "." + strings.ToLower(ext)
 }
 
 // getBucketFromObjectKind returns the appropriate bucket name based on the object kind

--- a/ms_user/Dockerfile.dev
+++ b/ms_user/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine
+FROM golang:1.25-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Refactor R2 object key generation to a flat filename format with media extension, and align usages across `content_service`. Also bump Go base images in dev Dockerfiles.

## Key Changes

- **Object key format**: `buildObjectKey` now returns `<userId>/spaces/<spaceId>/content/<contentSourceId>.<ext>` instead of nesting the original filename as a child path.
- **Extension handling**: Extracts extension from provided filename via `filepath.Ext`; defaults to `bin` when missing; coerces to lowercase.
- **Service updates**: All call sites in `content_service.go` updated to use the new key format consistently for upload, confirm, and download flows.
- **Dev images**: Bump `golang` versions in `ms_knowledge/Dockerfile.dev` and `ms_user/Dockerfile.dev` to 1.25 (and alpine variant for user service).

## Detailed Description

### Technical Implementation
- Updated imports to include `path/filepath`.
- Reworked `buildObjectKey(ownerID, spaceID, contentID, filename)` implementation and sanitized filename usage.
- Adjusted `CreateUploadURL`, `ConfirmUpload`, and `GenerateDownloadURL` to rely on the updated key builder.
- No storage API changes; only object key shape changed.

### Tests / Verification
- Verified presigned URL generation uses the new key shape.
- Ensured event emission (`DocumentUploadedEvent`) references the new key format.
- Manual verification recommended: Upload, confirm, and download a file with and without extensions; verify R2 object keys and accessibility.

### Breaking Changes
- Potentially breaking for consumers or scripts relying on the previous nested key structure (e.g., assuming original filename in the path). Migration may be needed for existing objects if downstream systems expect the old structure.

### Migration / Rollout Notes
- Consider adding a compatibility read path for legacy keys if existing data must remain accessible.
- Coordinate with any batch jobs or lambdas parsing object keys.

### Linked Issues
- N/A (please link if applicable)

### Checklist
- [x] Code refactor isolated to key generation and call sites
- [x] Dev Docker images updated to Go 1.25
- [ ] Manual tests across upload/confirm/download for files with/without extensions
- [ ] Verify no consumers require the old key format, or provide fallback


