### PR TITLE
feat(llm): shared LLM provider package (OpenAI, Vertex, Gemini)

### DIFF
--- a/pkg/__init__.py
+++ b/pkg/__init__.py
@@ -1,0 +1,1 @@
+"""Shared packages for all microservices."""

--- a/pkg/llm/README.md
+++ b/pkg/llm/README.md
@@ -1,0 +1,194 @@
+# LLM Provider Package
+
+Shared package for multiple LLM providers across all microservices.
+
+## Overview
+
+This package provides a unified interface for generating document insights (summaries and keywords) using different LLM providers:
+
+- **OpenAI** (default): gpt-5-mini-2025-08-07 or other OpenAI models
+- **Vertex AI**: Google Cloud Vertex AI with Gemini models
+- **Gemini**: Google Gemini API (backward compatibility)
+
+## Architecture
+
+```
+pkg/llm/
+├── __init__.py          # Package exports
+├── base.py              # Abstract LLMProvider base class
+├── types.py             # Shared types (InsightRequest, InsightResponse)
+├── factory.py           # Provider factory and configuration
+└── providers/
+    ├── __init__.py
+    ├── openai.py        # OpenAI Chat Completions API
+    ├── vertex.py        # Google Vertex AI
+    └── gemini.py        # Google Gemini API
+```
+
+## Usage
+
+### Basic Usage
+
+```python
+from pkg.llm import LLMProviderFactory, LLMProviderConfig, LLMProviderType
+
+# Configure OpenAI provider (default)
+config = LLMProviderConfig(
+    provider_type=LLMProviderType.OPENAI,
+    openai_api_key="your-api-key",
+    openai_model="gpt-5-mini-2025-08-07",
+    temperature=0.2,
+    top_p=0.95,
+)
+
+# Create provider
+provider = LLMProviderFactory.create_provider(config)
+
+# Generate insights
+response = provider.generate_insights(
+    document_text="Your document content here...",
+    title="Document Title",
+    summary_tokens=512,
+    keyword_count=10,
+)
+
+print(response.summary)
+print(response.keywords)
+```
+
+### Using Vertex AI
+
+```python
+config = LLMProviderConfig(
+    provider_type=LLMProviderType.VERTEX,
+    vertex_project_id="your-gcp-project",
+    vertex_location="us-central1",
+    vertex_model="gemini-1.5-flash",
+)
+
+provider = LLMProviderFactory.create_provider(config)
+response = provider.generate_insights(document_text="...")
+```
+
+### Using Gemini API
+
+```python
+config = LLMProviderConfig(
+    provider_type=LLMProviderType.GEMINI,
+    gemini_api_key="your-gemini-key",
+    gemini_model="models/gemini-1.5-flash",
+)
+
+provider = LLMProviderFactory.create_provider(config)
+response = provider.generate_insights(document_text="...")
+```
+
+## Configuration
+
+### Environment Variables
+
+Set these in your microservice's `.env.local`:
+
+```bash
+# Provider selection (openai | vertex | gemini)
+LLM_PROVIDER=openai
+
+# Common settings
+LLM_TEMPERATURE=0.2
+LLM_TOP_P=0.95
+LLM_SUMMARY_TOKENS=512
+LLM_KEYWORD_COUNT=10
+
+# OpenAI (default)
+OPENAI_API_KEY=your_openai_api_key
+OPENAI_MODEL=gpt-5-mini-2025-08-07
+
+# Vertex AI (optional)
+VERTEX_PROJECT_ID=your_gcp_project
+VERTEX_LOCATION=us-central1
+VERTEX_MODEL=gemini-1.5-flash
+
+# Gemini API (optional)
+GEMINI_API_KEY=your_gemini_key
+GEMINI_MODEL=models/gemini-1.5-flash
+```
+
+## Integration with Microservices
+
+To use this package in a microservice:
+
+1. Add the pkg path to Python path:
+
+```python
+import sys
+from pathlib import Path
+
+pkg_path = Path(__file__).resolve().parents[4] / "pkg"
+if str(pkg_path) not in sys.path:
+    sys.path.insert(0, str(pkg_path))
+
+from pkg.llm import LLMProviderFactory, LLMProviderConfig, LLMProviderType
+```
+
+2. Configure and use the provider based on your settings.
+
+## Response Format
+
+All providers return a consistent `InsightResponse`:
+
+```python
+class InsightResponse(BaseModel):
+    summary: str              # Generated summary
+    keywords: List[str]       # Extracted keywords
+```
+
+## Dependencies
+
+Required packages (add to your microservice's `pyproject.toml`):
+
+```toml
+openai = "^1.50.0"                    # For OpenAI provider
+google-cloud-aiplatform = "^1.70.0"   # For Vertex AI provider
+google-generativeai = "^0.8.5"        # For Gemini provider
+```
+
+## Error Handling
+
+All providers raise `RuntimeError` on failure:
+
+```python
+try:
+    response = provider.generate_insights(document_text="...")
+except RuntimeError as e:
+    logger.error(f"Failed to generate insights: {e}")
+```
+
+## Adding New Providers
+
+To add a new provider:
+
+1. Create a new file in `providers/` (e.g., `anthropic.py`)
+2. Implement the `LLMProvider` base class
+3. Add provider type to `LLMProviderType` enum in `factory.py`
+4. Add provider creation logic to `LLMProviderFactory`
+5. Export from `providers/__init__.py`
+
+## Testing
+
+Mock the provider in tests:
+
+```python
+from unittest.mock import MagicMock, patch
+from pkg.llm.types import InsightResponse
+
+@patch("your_module.LLMProviderFactory.create_provider")
+def test_with_mocked_provider(mock_create_provider):
+    mock_provider = MagicMock()
+    mock_provider.generate_insights.return_value = InsightResponse(
+        summary="Test summary",
+        keywords=["test", "keywords"]
+    )
+    mock_create_provider.return_value = mock_provider
+
+    # Your test code here
+```

--- a/pkg/llm/__init__.py
+++ b/pkg/llm/__init__.py
@@ -1,0 +1,17 @@
+"""Shared LLM package for multiple providers."""
+from pkg.llm.base import LLMProvider
+from pkg.llm.factory import LLMProviderConfig, LLMProviderFactory, LLMProviderType
+from pkg.llm.providers import GeminiProvider, OpenAIProvider, VertexAIProvider
+from pkg.llm.types import InsightRequest, InsightResponse
+
+__all__ = [
+    "LLMProvider",
+    "LLMProviderFactory",
+    "LLMProviderConfig",
+    "LLMProviderType",
+    "OpenAIProvider",
+    "VertexAIProvider",
+    "GeminiProvider",
+    "InsightRequest",
+    "InsightResponse",
+]

--- a/pkg/llm/base.py
+++ b/pkg/llm/base.py
@@ -1,0 +1,65 @@
+"""Base class for LLM providers."""
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from pkg.llm.types import InsightRequest, InsightResponse
+
+
+class LLMProvider(ABC):
+    """Abstract base class for LLM providers."""
+
+    @abstractmethod
+    def generate_insights(
+        self,
+        document_text: str,
+        title: Optional[str] = None,
+        summary_tokens: int = 512,
+        keyword_count: int = 10,
+    ) -> InsightResponse:
+        """
+        Generate insights (summary and keywords) from document text.
+
+        Args:
+            document_text: The document text to analyze
+            title: Optional document title for context
+            summary_tokens: Target token count for summary
+            keyword_count: Number of keywords to extract
+
+        Returns:
+            InsightResponse containing summary and keywords
+
+        Raises:
+            RuntimeError: If insight generation fails
+        """
+        pass
+
+    def _build_prompt(
+        self,
+        document_text: str,
+        title: Optional[str],
+        summary_tokens: int,
+        keyword_count: int,
+    ) -> str:
+        """
+        Build the prompt for insight generation.
+
+        Args:
+            document_text: The document text to analyze
+            title: Optional document title for context
+            summary_tokens: Target token count for summary
+            keyword_count: Number of keywords to extract
+
+        Returns:
+            Formatted prompt string
+        """
+        heading = f"Title: {title}\n" if title else ""
+        instructions = (
+            "You are an assistant that summarizes documents and extracts concise keywords.\n"
+            "Analyse the provided document and respond strictly with valid JSON matching the schema:\n"
+            '{"summary": string, "keywords": string[]}.\n'
+            "Guidelines:\n"
+            f"- The summary should be around {summary_tokens} tokens and cover essential points.\n"
+            f"- Return between 3 and {keyword_count} informative keywords.\n"
+            "- Do not include markdown or explanations outside the JSON object.\n"
+        )
+        return f"{instructions}{heading}\nDocument:\n{document_text}"

--- a/pkg/llm/factory.py
+++ b/pkg/llm/factory.py
@@ -1,0 +1,123 @@
+"""Factory for creating LLM provider instances."""
+import logging
+from enum import Enum
+from typing import Optional
+
+from pkg.llm.base import LLMProvider
+from pkg.llm.providers.gemini import GeminiProvider
+from pkg.llm.providers.openai import OpenAIProvider
+from pkg.llm.providers.vertex import VertexAIProvider
+
+logger = logging.getLogger(__name__)
+
+
+class LLMProviderType(str, Enum):
+    """Available LLM provider types."""
+    OPENAI = "openai"
+    VERTEX = "vertex"
+    GEMINI = "gemini"
+
+
+class LLMProviderConfig:
+    """Configuration for LLM providers."""
+
+    def __init__(
+        self,
+        provider_type: LLMProviderType = LLMProviderType.OPENAI,
+        # OpenAI config
+        openai_api_key: Optional[str] = None,
+        openai_model: str = "gpt-5-mini-2025-08-07",
+        # Vertex AI config
+        vertex_project_id: Optional[str] = None,
+        vertex_location: str = "us-central1",
+        vertex_model: str = "gemini-1.5-flash",
+        # Gemini config
+        gemini_api_key: Optional[str] = None,
+        gemini_model: str = "models/gemini-1.5-flash",
+        # Common config
+        temperature: float = 0.2,
+        top_p: float = 0.95,
+    ):
+        """
+        Initialize LLM provider configuration.
+
+        Args:
+            provider_type: Type of provider to use (default: openai)
+            openai_api_key: OpenAI API key
+            openai_model: OpenAI model name
+            vertex_project_id: GCP project ID for Vertex AI
+            vertex_location: GCP location for Vertex AI
+            vertex_model: Vertex AI model name
+            gemini_api_key: Gemini API key
+            gemini_model: Gemini model name
+            temperature: Sampling temperature
+            top_p: Nucleus sampling parameter
+        """
+        self.provider_type = provider_type
+        self.openai_api_key = openai_api_key
+        self.openai_model = openai_model
+        self.vertex_project_id = vertex_project_id
+        self.vertex_location = vertex_location
+        self.vertex_model = vertex_model
+        self.gemini_api_key = gemini_api_key
+        self.gemini_model = gemini_model
+        self.temperature = temperature
+        self.top_p = top_p
+
+
+class LLMProviderFactory:
+    """Factory for creating LLM provider instances."""
+
+    @staticmethod
+    def create_provider(config: LLMProviderConfig) -> LLMProvider:
+        """
+        Create an LLM provider instance based on configuration.
+
+        Args:
+            config: Provider configuration
+
+        Returns:
+            Configured LLM provider instance
+
+        Raises:
+            ValueError: If provider type is invalid or required credentials are missing
+        """
+        if config.provider_type == LLMProviderType.OPENAI:
+            if not config.openai_api_key:
+                raise ValueError("openai_api_key is required for OpenAI provider")
+            logger.info(f"Initializing OpenAI provider with model: {config.openai_model}")
+            return OpenAIProvider(
+                api_key=config.openai_api_key,
+                model=config.openai_model,
+                temperature=config.temperature,
+                top_p=config.top_p,
+            )
+
+        elif config.provider_type == LLMProviderType.VERTEX:
+            if not config.vertex_project_id:
+                raise ValueError("vertex_project_id is required for Vertex AI provider")
+            logger.info(
+                f"Initializing Vertex AI provider with model: {config.vertex_model}, "
+                f"project: {config.vertex_project_id}, location: {config.vertex_location}"
+            )
+            return VertexAIProvider(
+                project_id=config.vertex_project_id,
+                location=config.vertex_location,
+                model=config.vertex_model,
+                temperature=config.temperature,
+                top_p=config.top_p,
+            )
+
+        elif config.provider_type == LLMProviderType.GEMINI:
+            if not config.gemini_api_key:
+                raise ValueError("gemini_api_key is required for Gemini provider")
+            logger.info(f"Initializing Gemini provider with model: {config.gemini_model}")
+            return GeminiProvider(
+                api_key=config.gemini_api_key,
+                model=config.gemini_model,
+                temperature=config.temperature,
+                top_p=config.top_p,
+            )
+
+        else:
+            raise ValueError(f"Unsupported provider type: {config.provider_type}")

--- a/pkg/llm/providers/__init__.py
+++ b/pkg/llm/providers/__init__.py
@@ -1,0 +1,6 @@
+"""LLM provider implementations."""
+from pkg.llm.providers.gemini import GeminiProvider
+from pkg.llm.providers.openai import OpenAIProvider
+from pkg.llm.providers.vertex import VertexAIProvider
+
+__all__ = ["OpenAIProvider", "VertexAIProvider", "GeminiProvider"]

--- a/pkg/llm/providers/gemini.py
+++ b/pkg/llm/providers/gemini.py
@@ -1,0 +1,151 @@
+"""Google Gemini API provider implementation."""
+import json
+import logging
+from typing import Any, Optional
+
+import google.generativeai as genai
+from google.api_core.exceptions import GoogleAPIError
+from google.generativeai import types as genai_types
+
+from pkg.llm.base import LLMProvider
+from pkg.llm.types import InsightResponse
+
+logger = logging.getLogger(__name__)
+
+
+class GeminiProvider(LLMProvider):
+    """Google Gemini API provider (for backward compatibility)."""
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "models/gemini-1.5-flash",
+        temperature: float = 0.2,
+        top_p: float = 0.95,
+    ):
+        """
+        Initialize Gemini provider.
+
+        Args:
+            api_key: Gemini API key
+            model: Model name (default: models/gemini-1.5-flash)
+            temperature: Sampling temperature (default: 0.2)
+            top_p: Nucleus sampling parameter (default: 0.95)
+        """
+        if not api_key:
+            raise ValueError("api_key is required for Gemini provider")
+
+        genai.configure(api_key=api_key)
+        self._model = genai.GenerativeModel(model)
+        self.temperature = temperature
+        self.top_p = top_p
+
+    def generate_insights(
+        self,
+        document_text: str,
+        title: Optional[str] = None,
+        summary_tokens: int = 512,
+        keyword_count: int = 10,
+    ) -> InsightResponse:
+        """Generate insights using Gemini API."""
+        try:
+            response = self._model.generate_content(
+                contents=self._build_prompt(document_text, title, summary_tokens, keyword_count),
+                generation_config=genai_types.GenerationConfig(
+                    temperature=self.temperature,
+                    top_p=self.top_p,
+                    response_mime_type="application/json",
+                    response_schema={
+                        "type": "object",
+                        "properties": {
+                            "summary": {"type": "string"},
+                            "keywords": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "min_items": min(3, keyword_count),
+                                "max_items": keyword_count,
+                            },
+                        },
+                        "required": ["summary", "keywords"],
+                    },
+                ),
+            )
+            return self._parse_response(response)
+
+        except GoogleAPIError as err:
+            logger.warning("Gemini API error while generating insights", exc_info=True)
+            raise RuntimeError("Failed to generate document insights") from err
+
+    def _parse_response(self, response: Any) -> InsightResponse:
+        """Parse Gemini response to InsightResponse."""
+        try:
+            # Try parsed response first
+            parsed = getattr(response, "parsed", None)
+            if isinstance(parsed, dict):
+                summary = parsed.get("summary", "")
+                keywords = parsed.get("keywords", [])
+                return self._clean_response(summary, keywords)
+
+            # Fall back to text extraction
+            raw_text = self._extract_text(response)
+            if not raw_text or not raw_text.strip():
+                logger.warning("Received empty response from Gemini API")
+                return InsightResponse(summary="", keywords=[])
+
+            payload = json.loads(raw_text)
+            summary = payload.get("summary", "") if isinstance(payload, dict) else ""
+            keywords = payload.get("keywords", []) if isinstance(payload, dict) else []
+            return self._clean_response(summary, keywords)
+
+        except Exception:
+            logger.warning("Failed to parse Gemini response", exc_info=True)
+            return InsightResponse(summary="", keywords=[])
+
+    @staticmethod
+    def _extract_text(response: Any) -> str:
+        """Extract text from Gemini response."""
+        try:
+            text_value = getattr(response, "text")
+        except (AttributeError, ValueError):
+            text_value = None
+
+        if text_value:
+            return text_value
+
+        candidates = getattr(response, "candidates", None)
+        if candidates:
+            for candidate in candidates:
+                content = getattr(candidate, "content", None)
+                if content:
+                    for part in getattr(content, "parts", []):
+                        text = getattr(part, "text", None)
+                        if text:
+                            return text
+                        if hasattr(part, "function_response"):
+                            function_response = getattr(part, "function_response")
+                            if function_response and function_response.response:
+                                try:
+                                    return json.dumps(function_response.response)
+                                except (TypeError, ValueError):
+                                    logger.debug("Unable to serialize function response", exc_info=True)
+                        if hasattr(part, "parsed") and part.parsed:
+                            try:
+                                return json.dumps(part.parsed)
+                            except (TypeError, ValueError):
+                                logger.debug("Unable to serialize parsed part", exc_info=True)
+        return str(response)
+
+    def _clean_response(self, summary: str, keywords) -> InsightResponse:
+        """Clean and validate response data."""
+        cleaned_keywords = []
+        if keywords:
+            if isinstance(keywords, str):
+                # Handle string representation
+                kw_str = keywords.strip()
+                if kw_str.startswith('[') and kw_str.endswith(']'):
+                    kw_str = kw_str[1:-1]
+                cleaned_keywords = [kw.strip().strip('"\'') for kw in kw_str.split(',') if kw.strip()]
+            elif isinstance(keywords, list):
+                cleaned_keywords = [kw.strip() for kw in keywords if isinstance(kw, str) and kw.strip()]
+
+        return InsightResponse(summary=summary.strip(), keywords=cleaned_keywords)

--- a/pkg/llm/providers/openai.py
+++ b/pkg/llm/providers/openai.py
@@ -1,0 +1,102 @@
+"""OpenAI provider implementation."""
+import json
+import logging
+from typing import Optional
+
+from openai import OpenAI
+from openai.types.chat import ChatCompletion
+
+from pkg.llm.base import LLMProvider
+from pkg.llm.types import InsightResponse
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIProvider(LLMProvider):
+    """OpenAI Chat Completions API provider."""
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "gpt-5-mini-2025-08-07",
+        temperature: float = 0.2,
+        top_p: float = 0.95,
+    ):
+        """
+        Initialize OpenAI provider.
+
+        Args:
+            api_key: OpenAI API key
+            model: Model name (default: gpt-5-mini-2025-08-07)
+            temperature: Sampling temperature (default: 0.2)
+            top_p: Nucleus sampling parameter (default: 0.95)
+        """
+        if not api_key:
+            raise ValueError("api_key is required for OpenAI provider")
+
+        self.client = OpenAI(api_key=api_key)
+        self.model = model
+        self.temperature = temperature
+        self.top_p = top_p
+
+    def generate_insights(
+        self,
+        document_text: str,
+        title: Optional[str] = None,
+        summary_tokens: int = 512,
+        keyword_count: int = 10,
+    ) -> InsightResponse:
+        """Generate insights using OpenAI Chat Completions API."""
+        try:
+            response: ChatCompletion = self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "You are a helpful assistant that generates document summaries and keywords in JSON format.",
+                    },
+                    {
+                        "role": "user",
+                        "content": self._build_prompt(
+                            document_text, title, summary_tokens, keyword_count
+                        ),
+                    },
+                ],
+                temperature=self.temperature,
+                top_p=self.top_p,
+                response_format={"type": "json_object"},
+            )
+
+            return self._parse_response(response)
+
+        except Exception as err:
+            logger.warning("OpenAI API error while generating insights", exc_info=True)
+            raise RuntimeError("Failed to generate document insights") from err
+
+    def _parse_response(self, response: ChatCompletion) -> InsightResponse:
+        """Parse OpenAI response to InsightResponse."""
+        try:
+            if not response.choices:
+                logger.warning("Received empty choices from OpenAI API")
+                return InsightResponse(summary="", keywords=[])
+
+            message = response.choices[0].message
+            if not message.content:
+                logger.warning("Received empty content from OpenAI API")
+                return InsightResponse(summary="", keywords=[])
+
+            payload = json.loads(message.content)
+            summary = payload.get("summary", "") if isinstance(payload, dict) else ""
+            keywords = payload.get("keywords", []) if isinstance(payload, dict) else []
+
+            # Clean keywords
+            if isinstance(keywords, list):
+                keywords = [kw.strip() for kw in keywords if isinstance(kw, str) and kw.strip()]
+            else:
+                keywords = []
+
+            return InsightResponse(summary=summary.strip(), keywords=keywords)
+
+        except Exception:
+            logger.warning("Failed to parse OpenAI response", exc_info=True)
+            return InsightResponse(summary="", keywords=[])

--- a/pkg/llm/providers/vertex.py
+++ b/pkg/llm/providers/vertex.py
@@ -1,0 +1,120 @@
+"""Vertex AI provider implementation."""
+import json
+import logging
+from typing import Optional
+
+from google.cloud import aiplatform
+from vertexai.generative_models import GenerationConfig, GenerativeModel
+
+from pkg.llm.base import LLMProvider
+from pkg.llm.types import InsightResponse
+
+logger = logging.getLogger(__name__)
+
+
+class VertexAIProvider(LLMProvider):
+    """Google Vertex AI provider."""
+
+    def __init__(
+        self,
+        project_id: str,
+        location: str = "us-central1",
+        model: str = "gemini-1.5-flash",
+        temperature: float = 0.2,
+        top_p: float = 0.95,
+    ):
+        """
+        Initialize Vertex AI provider.
+
+        Args:
+            project_id: GCP project ID
+            location: GCP location (default: us-central1)
+            model: Model name (default: gemini-1.5-flash)
+            temperature: Sampling temperature (default: 0.2)
+            top_p: Nucleus sampling parameter (default: 0.95)
+        """
+        if not project_id:
+            raise ValueError("project_id is required for Vertex AI provider")
+
+        aiplatform.init(project=project_id, location=location)
+        self.model = GenerativeModel(model)
+        self.temperature = temperature
+        self.top_p = top_p
+
+    def generate_insights(
+        self,
+        document_text: str,
+        title: Optional[str] = None,
+        summary_tokens: int = 512,
+        keyword_count: int = 10,
+    ) -> InsightResponse:
+        """Generate insights using Vertex AI."""
+        try:
+            generation_config = GenerationConfig(
+                temperature=self.temperature,
+                top_p=self.top_p,
+                response_mime_type="application/json",
+                response_schema={
+                    "type": "object",
+                    "properties": {
+                        "summary": {"type": "string"},
+                        "keywords": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "minItems": min(3, keyword_count),
+                            "maxItems": keyword_count,
+                        },
+                    },
+                    "required": ["summary", "keywords"],
+                },
+            )
+
+            response = self.model.generate_content(
+                contents=self._build_prompt(document_text, title, summary_tokens, keyword_count),
+                generation_config=generation_config,
+            )
+
+            return self._parse_response(response)
+
+        except Exception as err:
+            logger.warning("Vertex AI error while generating insights", exc_info=True)
+            raise RuntimeError("Failed to generate document insights") from err
+
+    def _parse_response(self, response) -> InsightResponse:
+        """Parse Vertex AI response to InsightResponse."""
+        try:
+            # Try to get parsed response first
+            parsed = getattr(response, "parsed", None)
+            if isinstance(parsed, dict):
+                summary = parsed.get("summary", "")
+                keywords = parsed.get("keywords", [])
+                return self._clean_response(summary, keywords)
+
+            # Fall back to text parsing
+            text = getattr(response, "text", None)
+            if text:
+                payload = json.loads(text)
+                summary = payload.get("summary", "") if isinstance(payload, dict) else ""
+                keywords = payload.get("keywords", []) if isinstance(payload, dict) else []
+                return self._clean_response(summary, keywords)
+
+            logger.warning("Received empty response from Vertex AI")
+            return InsightResponse(summary="", keywords=[])
+
+        except Exception:
+            logger.warning("Failed to parse Vertex AI response", exc_info=True)
+            return InsightResponse(summary="", keywords=[])
+
+    def _clean_response(self, summary: str, keywords) -> InsightResponse:
+        """Clean and validate response data."""
+        cleaned_keywords = []
+        if isinstance(keywords, list):
+            cleaned_keywords = [kw.strip() for kw in keywords if isinstance(kw, str) and kw.strip()]
+        elif isinstance(keywords, str):
+            # Handle string representation of list
+            kw_str = keywords.strip()
+            if kw_str.startswith('[') and kw_str.endswith(']'):
+                kw_str = kw_str[1:-1]
+            cleaned_keywords = [kw.strip().strip('"\'') for kw in kw_str.split(',') if kw.strip()]
+
+        return InsightResponse(summary=summary.strip(), keywords=cleaned_keywords)

--- a/pkg/llm/types.py
+++ b/pkg/llm/types.py
@@ -1,0 +1,28 @@
+"""Shared types for LLM providers."""
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class InsightRequest(BaseModel):
+    """
+    Request for generating document insights.
+    
+    Usages:
+        - ms_document_process : generate_insights
+    """
+    document_text: str = Field(..., description="The document text to analyze")
+    title: Optional[str] = Field(None, description="Optional document title for context")
+    summary_tokens: int = Field(512, description="Target token count for summary")
+    keyword_count: int = Field(10, description="Number of keywords to extract")
+
+
+class InsightResponse(BaseModel):
+    """
+    Response containing generated document insights.
+    
+    Usages:
+        - ms_document_process : generate_insights
+    """
+    summary: str = Field(..., description="Summarized content")
+    keywords: List[str] = Field(default_factory=list, description="Extracted keywords")


### PR DESCRIPTION
### Summary
- **Add shared LLM provider package** usable across microservices with a unified interface for generating document insights (summary + keywords).

### Key Changes
- **New package**: `pkg/llm` with a provider-agnostic API
  - `base.py`: abstract `LLMProvider` with `generate_insights`
  - `types.py`: `InsightRequest`, `InsightResponse` (Pydantic)
  - `factory.py`: `LLMProviderFactory` + `LLMProviderType` for `openai` | `vertex` | `gemini`
  - `providers/openai.py`: OpenAI Chat Completions w/ structured JSON output
  - `providers/vertex.py`: Vertex AI (Gemini) with response schema + parsing
  - `providers/gemini.py`: Gemini API (backward compatible) with robust parsing
  - `__init__.py` exports
- **Docs**: `pkg/llm/README.md` usage, config, and integration guide

### Technical Notes
- All providers return a consistent `InsightResponse` with `summary` and `keywords: string[]`.
- Prompts instruct models to strictly return JSON; parsers include safe fallbacks.
- Factory validates required credentials per provider and logs initialization details.

### Config / Env
- Provider selected via env (e.g., `LLM_PROVIDER=openai|vertex|gemini`).
- Common knobs: `LLM_TEMPERATURE`, `LLM_TOP_P`, `LLM_SUMMARY_TOKENS`, `LLM_KEYWORD_COUNT`.
- Per-provider credentials (e.g., `OPENAI_API_KEY`, `VERTEX_PROJECT_ID`, `GEMINI_API_KEY`).

### Dependencies (per service using this package)
- `openai` for OpenAI
- `google-cloud-aiplatform` and `vertexai` for Vertex AI
- `google-generativeai` for Gemini API

### Tests / Verification
- Manually validated JSON parsing paths and empty/edge cases in provider parsers.
- Recommend adding service-level unit tests by mocking `LLMProviderFactory.create_provider`.
